### PR TITLE
Expand Ashby slug pool, add slug verification utility, and expose Ashby filters in API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,10 @@ PORT=3001
 
 # How many jobs to fetch (default when no range specified)
 JOB_COUNT=10
+
+# Ashby smart ingestion filters
+ASHBY_KEYWORDS=early career,sde,robotics
+ASHBY_PUBLISHED_WITHIN_HOURS=24
+ASHBY_INCLUDE_COMPENSATION=true
+ASHBY_REQUEST_DELAY_MS=1000
+

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Ashby Job Boards   ─┘      Step 4: Sync to Airtable
 | **GitHub** | None | Parses SimplifyJobs/New-Grad-Positions README |
 | **Y Combinator** | RapidAPI key | YC company job listings |
 | **JSearch** | RapidAPI key | Broad job search API (Indeed, LinkedIn, etc.) |
-| **Ashby** | None | Scrapes public Ashby job boards (OpenAI, Ramp, Notion, Cursor, etc.) |
+| **Ashby** | None | Uses Ashby public posting API, then backend filters by keywords + publishedAt freshness |
 
 ## Quick Start
 
@@ -65,6 +65,10 @@ cp .env.example .env
 | `RAPIDAPI_KEY` | For YC/JSearch | RapidAPI key for YC and JSearch sources |
 | `CLAUDE_MODEL` | No | Defaults to `claude-3-5-haiku-20241022` |
 | `JOB_COUNT` | No | Default number of jobs to fetch (default: 10) |
+| `ASHBY_KEYWORDS` | No | Comma-separated keywords applied in backend filtering (default: `early career,sde,robotics`) |
+| `ASHBY_PUBLISHED_WITHIN_HOURS` | No | Keep Ashby jobs with `publishedAt` in the last N hours (default: `24`) |
+| `ASHBY_INCLUDE_COMPENSATION` | No | Calls Ashby with `includeCompensation=true` when enabled (default: `true`) |
+| `ASHBY_REQUEST_DELAY_MS` | No | Delay between Ashby company requests to stay within fair use (default: `1000`) |
 
 ### Run Locally
 
@@ -82,8 +86,8 @@ pnpm dev
 JobsList/
 ├── backend/
 │   └── src/
-│       ├── services/          # Fetchers (CSV, GitHub, YC, JSearch, Ashby)
-│       │                      # Scraper, AI processor, Airtable sync
+│       ├── services/          # Fetchers (CSV, GitHub, YC, JSearch, Ashby public API)
+│       │                      # Ashby filter logic, scraper, AI processor, Airtable sync
 │       ├── routes/            # Pipeline + data API routes
 │       ├── constants/         # Industry categories
 │       ├── config.ts          # Environment config
@@ -103,7 +107,7 @@ JobsList/
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/api/health` | GET | Health check |
-| `/api/pipeline/step1?source=<src>` | POST | Fetch raw jobs |
+| `/api/pipeline/step1?source=<src>` | POST | Fetch raw jobs (Ashby supports `companies`, `keywords`, `postedToday`, `publishedWithinHours`, `limit`) |
 | `/api/pipeline/step2` | POST | Scrape job descriptions |
 | `/api/pipeline/step3` | POST | AI process with Claude |
 | `/api/pipeline/step4` | POST | Sync to Airtable |
@@ -111,6 +115,32 @@ JobsList/
 | `/api/pipeline/reset` | POST | Clear all data |
 | `/api/data/:step` | GET | Get output from step 1-4 |
 | `/api/logs/stream` | GET | SSE real-time log stream |
+
+
+### Ashby Smart Ingestion Request Example
+
+```bash
+# Fetch the newest 25 jobs posted today that match keywords from selected Ashby companies
+curl -X POST "http://localhost:3001/api/pipeline/step1?source=theirstack&companies=openai,notion,cursor&keywords=sde,robotics&postedToday=true&limit=25"
+```
+
+- `companies`: comma-separated Ashby slugs to search (omit to search all configured companies)
+- `keywords`: comma-separated keywords (omit to use `ASHBY_KEYWORDS`)
+- `postedToday=true`: keep only jobs whose `publishedAt` date is today (UTC)
+- `publishedWithinHours`: optional alternative to `postedToday` (e.g., `24`)
+- No API key is required for Ashby public job board ingestion.
+
+
+### Ashby Slug Verification Utility
+
+Use the helper script to maintain or verify slug candidates:
+
+```bash
+python scripts/ashby_slugs_verified.py
+python scripts/ashby_slugs_verified.py --verify
+```
+
+The backend now includes a larger built-in Ashby slug pool and also supports request-level company selection via `companies=<slug1,slug2,...>`.
 
 ## AI Processing
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
         "@fastify/cors": "^10.0.0",
+        "@fastify/static": "^9.0.0",
         "airtable": "^0.12.2",
         "cheerio": "^1.0.0",
         "csv-parse": "^5.6.0",
@@ -494,6 +495,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/@fastify/accept-negotiator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/accept-negotiator/-/accept-negotiator-2.0.1.tgz",
+      "integrity": "sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@fastify/ajv-compiler": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.5.tgz",
@@ -623,6 +640,83 @@
       "dependencies": {
         "@fastify/forwarded": "^3.0.0",
         "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@fastify/send": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/send/-/send-4.1.0.tgz",
+      "integrity": "sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.2",
+        "escape-html": "~1.0.3",
+        "fast-decode-uri-component": "^1.0.1",
+        "http-errors": "^2.0.0",
+        "mime": "^3"
+      }
+    },
+    "node_modules/@fastify/static": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.0.0.tgz",
+      "integrity": "sha512-r64H8Woe/vfilg5RTy7lwWlE8ZZcTrc3kebYFMEUBrMqlydhQyoiExQXdYAy2REVpST/G35+stAM8WYp1WGmMA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/accept-negotiator": "^2.0.0",
+        "@fastify/send": "^4.0.0",
+        "content-disposition": "^1.0.1",
+        "fastify-plugin": "^5.0.0",
+        "fastq": "^1.17.1",
+        "glob": "^13.0.0"
+      }
+    },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@pinojs/redact": {
@@ -839,6 +933,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -893,6 +1000,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/dequal": {
@@ -1096,6 +1212,12 @@
         "@esbuild/win32-ia32": "0.27.2",
         "@esbuild/win32-x64": "0.27.2"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
@@ -1348,6 +1470,23 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/glob": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.2.tgz",
+      "integrity": "sha512-035InabNu/c1lW0tzPhAgapKctblppqsKKG9ZaNzbr+gXwWMjXoiyGSyB9sArzrjG7jY+zntRq5ZSUYemrnWVQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.1.2",
+        "minipass": "^7.1.2",
+        "path-scurry": "^2.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -1430,6 +1569,26 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -1450,6 +1609,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/ipaddr.js": {
       "version": "2.3.0",
@@ -1528,6 +1693,15 @@
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1535,6 +1709,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -1556,6 +1742,30 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
+      "integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mnemonist": {
@@ -1687,6 +1897,22 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/pino": {
@@ -1869,6 +2095,12 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/sonic-boom": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
@@ -1885,6 +2117,15 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/thread-stream": {
@@ -1906,6 +2147,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/tr46": {

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -21,4 +21,15 @@ export const config = {
   rapidApiKey: process.env.RAPIDAPI_KEY || '',
   jsearchQuery: process.env.JSEARCH_QUERY || 'software developer jobs in USA',
   jsearchNumPages: parseInt(process.env.JSEARCH_NUM_PAGES || '1', 10),
+  ashbyKeywords: (process.env.ASHBY_KEYWORDS || 'early career,sde,robotics')
+    .split(',')
+    .map((keyword) => keyword.trim().toLowerCase())
+    .filter(Boolean),
+  ashbyPublishedWithinHours: parseInt(
+    process.env.ASHBY_PUBLISHED_WITHIN_HOURS || '24',
+    10
+  ),
+  ashbyIncludeCompensation:
+    (process.env.ASHBY_INCLUDE_COMPENSATION || 'true').toLowerCase() === 'true',
+  ashbyRequestDelayMs: parseInt(process.env.ASHBY_REQUEST_DELAY_MS || '1000', 10),
 };

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -25,10 +25,14 @@ export const config = {
     .split(',')
     .map((keyword) => keyword.trim().toLowerCase())
     .filter(Boolean),
-  ashbyPublishedWithinHours: parseInt(
-    process.env.ASHBY_PUBLISHED_WITHIN_HOURS || '24',
-    10
-  ),
+  ashbyPublishedWithinHours: (() => {
+    const parsed = parseInt(
+      process.env.ASHBY_PUBLISHED_WITHIN_HOURS || '24',
+      10
+    );
+    const safe = Number.isNaN(parsed) ? 24 : parsed;
+    return safe < 0 ? 0 : safe;
+  })(),
   ashbyIncludeCompensation:
     (process.env.ASHBY_INCLUDE_COMPENSATION || 'true').toLowerCase() === 'true',
   ashbyRequestDelayMs: parseInt(process.env.ASHBY_REQUEST_DELAY_MS || '1000', 10),

--- a/backend/src/routes/pipeline.ts
+++ b/backend/src/routes/pipeline.ts
@@ -47,37 +47,100 @@ function runStep(
     });
 }
 
-export async function pipelineRoutes(app: FastifyInstance): Promise<void> {
-  // Trigger Step 1: Fetch Jobs (CSV or GitHub)
-  app.post<{ Querystring: { source?: string; from?: string; to?: string; limit?: string } }>(
-    '/api/pipeline/step1',
-    async (request, reply) => {
-      if (pipelineStatus.step1.status === 'running') {
-        return reply.status(409).send({ error: 'Step 1 is already running' });
-      }
-      const source = request.query.source || 'csv';
-      const fromVal = parseInt(request.query.from || '', 10);
-      const toVal = parseInt(request.query.to || '', 10);
-      const limitVal = parseInt(request.query.limit || '', 10);
-      const range = !isNaN(fromVal) && !isNaN(toVal) ? { from: fromVal, to: toVal } : undefined;
-      // Calculate limit from range if provided, otherwise use explicit limit or default to 10
-      const limit = range ? (range.to - range.from + 1) : (!isNaN(limitVal) ? limitVal : 10);
-      log('system', 'info', `Step 1 params: from=${fromVal}, to=${toVal}, range=${JSON.stringify(range)}, limit=${limit}`);
+function parseCommaList(value?: string): string[] {
+  if (!value) {
+    return [];
+  }
 
-      if (source === 'github') {
-        runStep('step1', 'Step 1 (Fetch GitHub)', () => fetchGitHub(range));
-      } else if (source === 'yc') {
-        runStep('step1', 'Step 1 (Fetch YC)', () => fetchYC(range));
-      } else if (source === 'jsearch') {
-        runStep('step1', 'Step 1 (Fetch JSearch)', () => fetchJSearch(range));
-      } else if (source === 'theirstack') {
-        runStep('step1', 'Step 1 (Fetch TheirStack/Ashby)', () => fetchTheirStack(range));
-      } else {
-        runStep('step1', 'Step 1 (Fetch CSV)', () => fetchCsv(limit));
-      }
-      return reply.send({ status: 'started', step: 1, source });
+  return value
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function parseBoolean(value?: string): boolean {
+  if (!value) {
+    return false;
+  }
+
+  return ['1', 'true', 'yes', 'y'].includes(value.toLowerCase());
+}
+
+export async function pipelineRoutes(app: FastifyInstance): Promise<void> {
+  app.post<{
+    Querystring: {
+      source?: string;
+      from?: string;
+      to?: string;
+      limit?: string;
+      companies?: string;
+      keywords?: string;
+      postedToday?: string;
+      publishedWithinHours?: string;
+    };
+  }>('/api/pipeline/step1', async (request, reply) => {
+    if (pipelineStatus.step1.status === 'running') {
+      return reply.status(409).send({ error: 'Step 1 is already running' });
     }
-  );
+
+    const source = request.query.source || 'csv';
+    const fromVal = parseInt(request.query.from || '', 10);
+    const toVal = parseInt(request.query.to || '', 10);
+    const limitVal = parseInt(request.query.limit || '', 10);
+    const publishedWithinHoursVal = parseInt(request.query.publishedWithinHours || '', 10);
+    const range = !isNaN(fromVal) && !isNaN(toVal) ? { from: fromVal, to: toVal } : undefined;
+    const limit = !isNaN(limitVal) ? limitVal : 10;
+
+    const companies = parseCommaList(request.query.companies).map((slug) => slug.toLowerCase());
+    const keywords = parseCommaList(request.query.keywords).map((keyword) => keyword.toLowerCase());
+    const postedTodayOnly = parseBoolean(request.query.postedToday);
+    const publishedWithinHours = !isNaN(publishedWithinHoursVal)
+      ? publishedWithinHoursVal
+      : undefined;
+
+    log(
+      'system',
+      'info',
+      `Step 1 params: source=${source}, range=${JSON.stringify(range)}, limit=${limit}, companies=${companies.join('|') || 'all'}, keywords=${keywords.join('|') || 'default'}, postedToday=${postedTodayOnly}, publishedWithinHours=${publishedWithinHours ?? 'default'}`
+    );
+
+    if (source === 'github') {
+      runStep('step1', 'Step 1 (Fetch GitHub)', () => fetchGitHub(range));
+    } else if (source === 'yc') {
+      runStep('step1', 'Step 1 (Fetch YC)', () => fetchYC(range));
+    } else if (source === 'jsearch') {
+      runStep('step1', 'Step 1 (Fetch JSearch)', () => fetchJSearch(range));
+    } else if (source === 'theirstack') {
+      runStep('step1', 'Step 1 (Fetch TheirStack/Ashby)', () =>
+        fetchTheirStack({
+          range,
+          limit,
+          companySlugs: companies,
+          keywords,
+          postedTodayOnly,
+          publishedWithinHours,
+        })
+      );
+    } else {
+      runStep('step1', 'Step 1 (Fetch CSV)', () => fetchCsv(limit));
+    }
+
+    return reply.send({
+      status: 'started',
+      step: 1,
+      source,
+      filters:
+        source === 'theirstack'
+          ? {
+              companies,
+              keywords,
+              postedToday: postedTodayOnly,
+              publishedWithinHours,
+              limit,
+            }
+          : undefined,
+    });
+  });
 
   // Trigger Step 2: Scrape JDs
   app.post('/api/pipeline/step2', async (_request, reply) => {

--- a/backend/src/services/theirstack-fetcher.ts
+++ b/backend/src/services/theirstack-fetcher.ts
@@ -156,7 +156,7 @@ function extractLocation(location: AshbyJobPosting['location']): string | null {
   }
 
   if (typeof location === 'string') {
-    return location || null;
+    return location === '' ? null : location;
   }
 
   return location.locationName || location.location || null;

--- a/backend/src/services/theirstack-fetcher.ts
+++ b/backend/src/services/theirstack-fetcher.ts
@@ -191,22 +191,27 @@ async function fetchCompanyJobs(
     url.searchParams.set('includeCompensation', 'true');
   }
 
-  const response = await fetch(url.toString(), {
-    method: 'GET',
-    headers: {
-      Accept: 'application/json',
-      'User-Agent': 'JobSync-Service/1.0',
-    },
-  });
+  try {
+    const response = await fetch(url.toString(), {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': 'JobSync-Service/1.0',
+      },
+    });
 
-  if (!response.ok) {
-    log('fetch', 'warn', `  Ashby API returned ${response.status} for ${slug}`);
+    if (!response.ok) {
+      log('fetch', 'warn', `  Ashby API returned ${response.status} for ${slug}`);
+      return [];
+    }
+
+    const result: AshbyPublicResponse = await response.json();
+    const postings = result.jobs ?? [];
+    return postings.map((posting) => ({ company: companyName, slug, posting }));
+  } catch (error) {
+    log('fetch', 'error', `  Network error fetching ${slug}: ${error instanceof Error ? error.message : String(error)}`);
     return [];
   }
-
-  const result: AshbyPublicResponse = await response.json();
-  const postings = result.jobs ?? [];
-  return postings.map((posting) => ({ company: companyName, slug, posting }));
 }
 
 function toRawJob(entry: CompanyPosting): RawJob {

--- a/backend/src/services/theirstack-fetcher.ts
+++ b/backend/src/services/theirstack-fetcher.ts
@@ -4,76 +4,199 @@ import { log } from '../logger.js';
 import { writeStep } from '../store.js';
 import type { RawJob } from '../types.js';
 
-const ASHBY_GQL_URL =
-  'https://jobs.ashbyhq.com/api/non-user-graphql?op=ApiJobBoardWithTeams';
-
-const ASHBY_QUERY = `query ApiJobBoardWithTeams($organizationHostedJobsPageName: String!) {
-  jobBoard: jobBoardWithTeams(organizationHostedJobsPageName: $organizationHostedJobsPageName) {
-    jobPostings {
-      id
-      title
-      employmentType
-      locationName
-      compensationTierSummary
-      secondaryLocations { locationName }
-    }
-  }
-}`;
+const ASHBY_PUBLIC_API_BASE = 'https://api.ashbyhq.com/posting-api/job-board';
 
 /**
  * Curated list of companies that use Ashby as their ATS.
- * slug = the organizationHostedJobsPageName used in jobs.ashbyhq.com/<slug>
- * Add or remove entries as needed.
+ * slug = jobs.ashbyhq.com/<slug>
  */
-const ASHBY_COMPANIES: { slug: string; name: string }[] = [
-  { slug: 'openai', name: 'OpenAI' },
-  { slug: 'deel', name: 'Deel' },
-  { slug: 'vanta', name: 'Vanta' },
-  { slug: 'notion', name: 'Notion' },
-  { slug: 'ramp', name: 'Ramp' },
-  { slug: 'cohere', name: 'Cohere' },
-  { slug: 'perplexity', name: 'Perplexity' },
-  { slug: 'benchling', name: 'Benchling' },
-  { slug: 'replit', name: 'Replit' },
-  { slug: 'ashby', name: 'Ashby' },
-  { slug: 'cursor', name: 'Cursor' },
-  { slug: 'cognition', name: 'Cognition' },
-  { slug: 'watershed', name: 'Watershed' },
-  { slug: 'linear', name: 'Linear' },
-  { slug: 'posthog', name: 'PostHog' },
-  { slug: 'clerk', name: 'Clerk' },
-  { slug: 'runway', name: 'Runway' },
+const ASHBY_COMPANY_SLUGS: string[] = [
+  'airtable', 'alan', 'altura', 'away', 'deliveroo', 'duolingo', 'flock-safety', 'hackerone',
+  'notion', 'opendoor', 'oyster', 'posthog', 'ramp', 'sequoia', 'sony', 'vanta', 'cursor',
+  'deel', 'harvey', 'modern-treasury', 'openai', 'reddit', 'shopify', 'snowflake', 'apify',
+  'ashby', 'buffer', 'factory', 'hcompany', 'jerry.ai', 'lightning', 'linear', 'lottie',
+  'lovable', 'notable', 'scribd', 'searchable', 'silver', 'tapcheck', 'blueberrypediatrics',
+  'cambly', 'checkly', 'cleric', 'continua', 'dryft', 'duck-duck-go', 'equals', 'firetiger',
+  'homevision', 'imprint', 'kombo', 'legionhealth', 'livekit', 'matterworks', 'meticulous',
+  'modal', 'norm-ai', 'office-hours', 'ontic', 'orb', 'parabola-io', 'pear', 'pear-vc',
+  'permitflow', 'sentilink', 'sfcompute', 'steel', 'tiplink', 'titan', 'turnstile',
+  'verge-genomics', 'virtahealth', 'vitalize', 'wirescreen', '15five', '6sense', 'aave',
+  'ada', 'adept', 'affinity', 'affirm', 'agora', 'ai21-labs', 'airbyte', 'alchemy', 'alloy',
+  'alma', 'amplitude', 'anaplan', 'anduril', 'angellist', 'anthropic', 'anyscale', 'apollo',
+  'applied-intuition', 'asana', 'assembly-ai', 'attio', 'aurora', 'baseten', 'benchling',
+  'braze', 'brex', 'canva', 'carta', 'chainalysis', 'character-ai', 'chime', 'circle',
+  'clerk', 'clickhouse', 'clockwise', 'coda', 'codeium', 'cohere', 'coinbase', 'contentful',
+  'courier', 'databricks', 'datadog', 'dbt-labs', 'deepgram', 'discord', 'docker', 'doordash',
+  'drata', 'figma', 'fireblocks', 'fivetran', 'fly', 'framer', 'front', 'gong', 'grafana-labs',
+  'grammarly', 'gusto', 'hashicorp', 'hightouch', 'hubspot', 'huggingface', 'instacart',
+  'intercom', 'ironclad', 'iterable', 'jasper', 'kraken', 'labelbox', 'launchdarkly',
+  'lemonade', 'loom', 'lyra-health', 'marqeta', 'materialize', 'mercury', 'metabase', 'miro',
+  'mistral', 'modal-labs', 'monday', 'navan', 'neon', 'newrelic', 'novu', 'nuro', 'opensea',
+  'oura', 'outreach', 'paddle', 'pandadoc', 'paxos', 'pendo', 'perplexity', 'personio',
+  'pinecone', 'plaid', 'planetscale', 'postman', 'prefect', 'productboard', 'pulley', 'pulumi',
+  'qdrant', 'railway', 'raycast', 'readme', 'remote', 'render', 'replicate', 'replit',
+  'resend', 'retool', 'rippling', 'root-insurance', 'runway', 'samsara', 'sanity', 'sardine',
+  'scale', 'secureframe', 'sentry', 'shield-ai', 'singlestore', 'skydio', 'slack', 'smartcar',
+  'snorkel', 'snyk', 'sourcegraph', 'spotify', 'spring-health', 'stability-ai', 'stainless',
+  'statsig', 'storyblok', 'stripe', 'stytch', 'substack', 'supabase', 'synthesia', 'tailscale',
+  'temporal', 'tenstorrent', 'thirdweb', 'timescale', 'toast', 'together', 'together-ai',
+  'trm-labs', 'twilio', 'uniswap', 'upstart', 'vapi', 'vercel', 'verkada', 'voiceflow',
+  'wandb', 'warp', 'watershed', 'weaviate', 'webflow', 'weights-biases', 'whimsical', 'whoop',
+  'writer', 'xata', 'yugabyte', 'zed', 'zip', 'zipline', 'zora', 'zuora'
 ];
+
+interface AshbyLocation {
+  location?: string;
+  locationName?: string;
+}
+
+interface AshbyCompensation {
+  summary?: string;
+}
 
 interface AshbyJobPosting {
   id: string;
-  title: string;
-  employmentType: string | null;
-  locationName: string | null;
-  compensationTierSummary: string | null;
-  secondaryLocations: { locationName: string }[];
+  title?: string;
+  applyUrl?: string;
+  location?: AshbyLocation | string | null;
+  department?: string | null;
+  team?: string | null;
+  descriptionPlain?: string | null;
+  publishedAt?: string | null;
+  compensation?: AshbyCompensation | null;
 }
 
-interface AshbyResponse {
-  data?: {
-    jobBoard?: {
-      jobPostings: AshbyJobPosting[];
-    };
-  };
+interface AshbyPublicResponse {
+  jobs?: AshbyJobPosting[];
+}
+
+interface CompanyPosting {
+  company: string;
+  slug: string;
+  posting: AshbyJobPosting;
+}
+
+export interface FetchAshbyOptions {
+  range?: { from: number; to: number };
+  limit?: number;
+  keywords?: string[];
+  companySlugs?: string[];
+  publishedWithinHours?: number;
+  postedTodayOnly?: boolean;
+}
+
+function normalizeText(value: string | null | undefined): string {
+  return (value || '').trim().toLowerCase();
+}
+
+function normalizeKeywords(input?: string[]): string[] {
+  if (!input || input.length === 0) {
+    return config.ashbyKeywords;
+  }
+
+  return input
+    .map((keyword) => keyword.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function hasKeywordMatch(posting: AshbyJobPosting, keywords: string[]): boolean {
+  if (keywords.length === 0) {
+    return true;
+  }
+
+  const haystack = [posting.title, posting.department, posting.team, posting.descriptionPlain]
+    .map((field) => normalizeText(field))
+    .join(' ');
+
+  return keywords.some((keyword) => haystack.includes(keyword));
+}
+
+function isPublishedTodayUTC(publishedAt: string | null | undefined): boolean {
+  if (!publishedAt) {
+    return false;
+  }
+
+  const publishedDate = new Date(publishedAt);
+  if (Number.isNaN(publishedDate.getTime())) {
+    return false;
+  }
+
+  const now = new Date();
+  return (
+    publishedDate.getUTCFullYear() === now.getUTCFullYear() &&
+    publishedDate.getUTCMonth() === now.getUTCMonth() &&
+    publishedDate.getUTCDate() === now.getUTCDate()
+  );
+}
+
+function isWithinLookback(
+  publishedAt: string | null | undefined,
+  lookbackHours: number
+): boolean {
+  if (!publishedAt) {
+    return false;
+  }
+
+  const publishedTime = Date.parse(publishedAt);
+  if (Number.isNaN(publishedTime)) {
+    return false;
+  }
+
+  if (lookbackHours <= 0) {
+    return true;
+  }
+
+  const cutoff = Date.now() - lookbackHours * 60 * 60 * 1000;
+  return publishedTime >= cutoff;
+}
+
+function extractLocation(location: AshbyJobPosting['location']): string | null {
+  if (!location) {
+    return null;
+  }
+
+  if (typeof location === 'string') {
+    return location || null;
+  }
+
+  return location.locationName || location.location || null;
+}
+
+function slugToCompanyName(slug: string): string {
+  return slug
+    .split(/[.-]/g)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function resolveCompanies(selectedSlugs?: string[]): { slug: string; name: string }[] {
+  const allCompanies = ASHBY_COMPANY_SLUGS.map((slug) => ({ slug, name: slugToCompanyName(slug) }));
+
+  if (!selectedSlugs || selectedSlugs.length === 0) {
+    return allCompanies;
+  }
+
+  const selectedSet = new Set(selectedSlugs.map((slug) => slug.trim().toLowerCase()));
+  return allCompanies.filter((company) => selectedSet.has(company.slug.toLowerCase()));
 }
 
 async function fetchCompanyJobs(
   slug: string,
-  companyName: string
-): Promise<{ company: string; posting: AshbyJobPosting }[]> {
-  const response = await fetch(ASHBY_GQL_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      operationName: 'ApiJobBoardWithTeams',
-      variables: { organizationHostedJobsPageName: slug },
-      query: ASHBY_QUERY,
-    }),
+  companyName: string,
+  includeCompensation: boolean
+): Promise<CompanyPosting[]> {
+  const url = new URL(`${ASHBY_PUBLIC_API_BASE}/${slug}`);
+  if (includeCompensation) {
+    url.searchParams.set('includeCompensation', 'true');
+  }
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      'User-Agent': 'JobSync-Service/1.0',
+    },
   });
 
   if (!response.ok) {
@@ -81,95 +204,94 @@ async function fetchCompanyJobs(
     return [];
   }
 
-  const result: AshbyResponse = await response.json();
-  const postings = result.data?.jobBoard?.jobPostings ?? [];
-  return postings.map((p) => ({ company: companyName, posting: p }));
+  const result: AshbyPublicResponse = await response.json();
+  const postings = result.jobs ?? [];
+  return postings.map((posting) => ({ company: companyName, slug, posting }));
 }
 
-function buildApplyLink(slug: string, jobId: string): string {
-  return `https://jobs.ashbyhq.com/${slug}/${jobId}`;
+function toRawJob(entry: CompanyPosting): RawJob {
+  const { company, slug, posting } = entry;
+
+  return {
+    id: crypto.randomUUID(),
+    positionTitle: posting.title?.trim() || 'Unknown Position',
+    company,
+    location: extractLocation(posting.location),
+    applyLink: posting.applyUrl || `https://jobs.ashbyhq.com/${slug}/${posting.id}`,
+    datePosted: posting.publishedAt || null,
+    salary: posting.compensation?.summary || null,
+    rawFields: {
+      source: 'ashby-posting-api',
+      ashbyJobId: posting.id,
+      ashbySlug: slug,
+      department: posting.department || '',
+      team: posting.team || '',
+    },
+  };
 }
 
-function formatLocation(posting: AshbyJobPosting): string | null {
-  const locations = [
-    posting.locationName,
-    ...posting.secondaryLocations.map((s) => s.locationName),
-  ].filter(Boolean);
-  return locations.length > 0 ? locations.join('; ') : null;
-}
+export async function fetchTheirStack(options: FetchAshbyOptions = {}): Promise<number> {
+  const companies = resolveCompanies(options.companySlugs);
+  const keywords = normalizeKeywords(options.keywords);
+  const lookbackHours = options.publishedWithinHours ?? config.ashbyPublishedWithinHours;
+  const postedTodayOnly = options.postedTodayOnly || false;
 
-export async function fetchTheirStack(range?: {
-  from: number;
-  to: number;
-}): Promise<number> {
-  const companies = ASHBY_COMPANIES;
-
+  log('fetch', 'info', `Fetching Ashby data for ${companies.length} selected companies...`);
   log(
     'fetch',
     'info',
-    `Fetching jobs from ${companies.length} Ashby company boards...`
+    `Filters: keywords=${keywords.join(', ') || 'none'}, postedTodayOnly=${postedTodayOnly}, publishedWithinHours=${lookbackHours}`
   );
 
-  const allEntries: { company: string; slug: string; posting: AshbyJobPosting }[] = [];
+  const collected: CompanyPosting[] = [];
 
   for (const { slug, name } of companies) {
     log('fetch', 'info', `  Fetching ${name} (${slug})...`);
 
-    const entries = await fetchCompanyJobs(slug, name);
-    if (entries.length > 0) {
-      allEntries.push(...entries.map((e) => ({ ...e, slug })));
-      log('fetch', 'info', `  ${name}: ${entries.length} jobs`);
-    } else {
-      log('fetch', 'info', `  ${name}: no jobs found`);
-    }
+    const entries = await fetchCompanyJobs(slug, name, config.ashbyIncludeCompensation);
+    log('fetch', 'info', `  ${name}: ${entries.length} jobs returned by Ashby`);
 
-    // Be polite to Ashby's servers
-    await new Promise((r) => setTimeout(r, 300));
+    const filteredByKeyword = entries.filter(({ posting }) => hasKeywordMatch(posting, keywords));
+    const filteredByDate = filteredByKeyword.filter(({ posting }) =>
+      postedTodayOnly
+        ? isPublishedTodayUTC(posting.publishedAt)
+        : isWithinLookback(posting.publishedAt, lookbackHours)
+    );
+
+    log('fetch', 'info', `  ${name}: ${filteredByDate.length} jobs after filters`);
+
+    collected.push(...filteredByDate);
+
+    if (config.ashbyRequestDelayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, config.ashbyRequestDelayMs));
+    }
   }
 
-  log('fetch', 'info', `Received ${allEntries.length} total Ashby jobs`);
+  const deduped = Array.from(new Map(collected.map((item) => [item.posting.id, item])).values())
+    .sort((a, b) => {
+      const aTime = Date.parse(a.posting.publishedAt || '') || 0;
+      const bTime = Date.parse(b.posting.publishedAt || '') || 0;
+      return bTime - aTime;
+    });
 
-  // Apply range
-  const from = range ? range.from : 1;
-  const to = range ? range.to : Math.min(allEntries.length, config.jobCount);
-  const sliced = allEntries.slice(from - 1, to);
-  log(
-    'fetch',
-    'info',
-    `Taking jobs ${from}–${to} out of ${allEntries.length} total`
-  );
+  log('fetch', 'info', `Collected ${deduped.length} filtered Ashby jobs`);
 
-  const jobs: RawJob[] = sliced.map((entry, idx) => {
-    const { company, slug, posting } = entry;
-    const job: RawJob = {
-      id: crypto.randomUUID(),
-      positionTitle: posting.title || 'Unknown Position',
-      company,
-      location: formatLocation(posting),
-      applyLink: buildApplyLink(slug, posting.id),
-      datePosted: null, // Ashby public API doesn't expose post date
-      salary: posting.compensationTierSummary || null,
-      rawFields: {
-        source: 'ashby',
-        ashbyJobId: posting.id,
-        ashbySlug: slug,
-        employmentType: posting.employmentType || '',
-      },
-    };
+  const from = options.range ? options.range.from : 1;
+  const to = options.range
+    ? options.range.to
+    : Math.min(deduped.length, options.limit ?? config.jobCount);
+  const sliced = deduped.slice(Math.max(0, from - 1), Math.max(0, to));
 
-    log(
-      'fetch',
-      'info',
-      `  [${idx + 1}] ${job.company} — ${job.positionTitle}`
-    );
+  log('fetch', 'info', `Taking jobs ${from}–${to} out of ${deduped.length} total`);
+
+  const jobs: RawJob[] = sliced.map((entry, index) => {
+    const job = toRawJob(entry);
+    log('fetch', 'info', `  [${index + 1}] ${job.company} — ${job.positionTitle}`);
     return job;
   });
 
   writeStep('step1-raw-jobs', jobs);
-  log(
-    'fetch',
-    'info',
-    `Step 1 complete: ${jobs.length} jobs saved (source: Ashby)`
-  );
+  log('fetch', 'info', `Step 1 complete: ${jobs.length} jobs saved (source: Ashby)`);
+
   return jobs.length;
 }

--- a/scripts/ashby_slugs_verified.py
+++ b/scripts/ashby_slugs_verified.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Generate and optionally verify Ashby slugs.
+
+Usage:
+  python scripts/ashby_slugs_verified.py
+  python scripts/ashby_slugs_verified.py --verify
+"""
+
+from __future__ import annotations
+import argparse
+import csv
+import json
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+# Compact curated seed list; can be extended over time.
+SLUGS = [
+    'airtable','alan','altura','away','deliveroo','duolingo','flock-safety','hackerone','notion','opendoor',
+    'oyster','posthog','ramp','sequoia','sony','vanta','cursor','deel','harvey','modern-treasury','openai',
+    'reddit','shopify','snowflake','apify','ashby','buffer','factory','hcompany','jerry.ai','lightning','linear',
+    'lottie','lovable','notable','scribd','searchable','silver','tapcheck','blueberrypediatrics','cambly','checkly',
+    'cleric','continua','dryft','duck-duck-go','equals','firetiger','homevision','imprint','kombo','legionhealth',
+    'livekit','matterworks','meticulous','modal','norm-ai','office-hours','ontic','orb','parabola-io','pear','pear-vc',
+    'permitflow','sentilink','sfcompute','steel','tiplink','titan','turnstile','verge-genomics','virtahealth','vitalize',
+    'wirescreen','anthropic','benchling','clerk','cohere','dbt-labs','perplexity','replit','runway','watershed'
+]
+
+
+def dedupe(slugs: list[str]) -> list[str]:
+    seen = set()
+    out = []
+    for slug in slugs:
+        key = slug.strip().lower()
+        if key and key not in seen:
+            seen.add(key)
+            out.append(key)
+    return out
+
+
+def verify_slug(slug: str) -> tuple[bool, int]:
+    url = f'https://jobs.ashbyhq.com/{slug}/jobs.json'
+    req = urllib.request.Request(url, headers={'User-Agent': 'JobSync-Service/1.0'})
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            if resp.status != 200:
+                return False, 0
+            payload = json.loads(resp.read().decode('utf-8'))
+            return True, len(payload.get('jobs', []))
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, json.JSONDecodeError):
+        return False, 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--verify', action='store_true')
+    args = parser.parse_args()
+
+    slugs = dedupe(SLUGS)
+    out_dir = Path(__file__).resolve().parent
+    txt_path = out_dir / 'ashby_slugs_curated.txt'
+    csv_path = out_dir / 'ashby_slugs_curated.csv'
+
+    txt_path.write_text('\n'.join(slugs) + '\n')
+
+    with csv_path.open('w', newline='') as f:
+        w = csv.writer(f)
+        w.writerow(['slug', 'job_board_url', 'jobs_json_url'])
+        for slug in slugs:
+            w.writerow([slug, f'https://jobs.ashbyhq.com/{slug}', f'https://jobs.ashbyhq.com/{slug}/jobs.json'])
+
+    print(f'Wrote {len(slugs)} slugs to {txt_path} and {csv_path}')
+
+    if args.verify:
+        verified_rows = []
+        for slug in slugs:
+            ok, jobs = verify_slug(slug)
+            if ok:
+                verified_rows.append((slug, jobs))
+
+        verified_csv = out_dir / 'ashby_slugs_curated_verified.csv'
+        with verified_csv.open('w', newline='') as f:
+            w = csv.writer(f)
+            w.writerow(['slug', 'job_count'])
+            for slug, jobs in sorted(verified_rows, key=lambda x: (-x[1], x[0])):
+                w.writerow([slug, jobs])
+
+        print(f'Verified {len(verified_rows)}/{len(slugs)} slugs. Output: {verified_csv}')
+
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Broaden Ashby coverage so Step 1 can scan many more public Ashby job boards by default.  
- Provide a reproducible utility to generate and optionally verify candidate Ashby slugs against `jobs.ashbyhq.com`.  
- Allow callers to restrict or filter Ashby ingestion per-request (`companies`, `keywords`, `postedToday`, `publishedWithinHours`) instead of only using a static built-in set.

### Description

- Replaced the small static company list with a much larger `ASHBY_COMPANY_SLUGS` array and updated the fetcher to use the Ashby public posting API (`backend/src/services/theirstack-fetcher.ts`) while adding parsing, normalization, keyword/date filters, request delays, and dynamic name generation via `slugToCompanyName` and `resolveCompanies`.  
- Added `FetchAshbyOptions` support and refactored `fetchTheirStack` to accept `companySlugs`, `keywords`, `postedTodayOnly`, `publishedWithinHours`, `limit`, and `range` and to return deduplicated, filtered `RawJob` objects.  
- Extended the Step 1 pipeline route to accept and parse new query parameters (`companies`, `keywords`, `postedToday`, `publishedWithinHours`, `limit`) and forward them into `fetchTheirStack` (`backend/src/routes/pipeline.ts`).  
- Added new env-config items in `backend/src/config.ts` to support `ASHBY_KEYWORDS`, `ASHBY_PUBLISHED_WITHIN_HOURS`, `ASHBY_INCLUDE_COMPENSATION`, and `ASHBY_REQUEST_DELAY_MS`.  
- Added `scripts/ashby_slugs_verified.py`, a small CLI that writes curated slug lists to disk and can optionally verify each slug by checking `https://jobs.ashbyhq.com/<slug>/jobs.json`.  
- Updated `README.md` with usage notes for the Ashby smart-ingestion request parameters and instructions for the slug verification utility.

### Testing

- Built the backend TypeScript with `pnpm --filter jobslist-backend build` and the build completed successfully.  
- Executed `python scripts/ashby_slugs_verified.py --verify` in this environment; the script ran and generated outputs, but network egress to `jobs.ashbyhq.com` is blocked here so verification returned `0/83` verified (no reachable endpoints).  
- No additional automated tests were added; existing build step passed and the new script and route parsing were exercised in the development environment described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cbf7adec08320b91803f7eac5c76c)