### PR TITLE
feat: add Anthropic integration for job search agent

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -94,7 +94,12 @@
       "Bash(grep -vE \"dtype|onnx|warn|Some|^$\")",
       "Bash(grep -vE \"dtype|onnx|warn|Some weights|^\\\\s*$\")",
       "Bash(rm es-smoke.mjs)",
-      "Bash(git -C \"c:\\\\Users\\\\vyasm\\\\OneDrive\\\\Desktop\\\\JobsList\" status --short mcp-server/)"
+      "Bash(git -C \"c:\\\\Users\\\\vyasm\\\\OneDrive\\\\Desktop\\\\JobsList\" status --short mcp-server/)",
+      "Skill(claude-api)",
+      "Skill(claude-api:*)",
+      "Bash(node -e \"console.log\\(require\\('./mcp-server/node_modules/@anthropic-ai/sdk/package.json'\\).version\\)\")",
+      "Bash(node -e \"console.log\\(require\\('@anthropic-ai/sdk/package.json'\\).version\\)\")",
+      "Bash(pnpm --filter jobsync-dashboard build)"
     ],
     "additionalDirectories": [
       "c:\\Users\\vyasm\\.claude\\projects\\c--Users-vyasm-OneDrive-Desktop-JobsList\\memory"

--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,10 @@ FIREBASE_API_KEY=
 # FIREBASE_PROJECT_ID=
 # FIREBASE_AUTH_DOMAIN=
 
+# Server-side Search agent (Phase 2). Shared deployment key.
+ANTHROPIC_API_KEY=sk-ant-...
+JOBSYNC_AGENT_MODEL=claude-sonnet-4-6
+
 # Server
 PORT=3001
 

--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -54,8 +54,10 @@ jobs:
             --cpu 1 \
             --min-instances 0 \
             --max-instances 3 \
+            --no-cpu-throttling \
+            --timeout 900 \
             --env-vars-file gcp.env.example.yaml \
-            --set-secrets AIRTABLE_API_KEY=jobsync-airtable-api-key:latest,AIRTABLE_BASE_ID=jobsync-airtable-base-id:latest,JOBSYNC_REMOTE_BEARER_TOKEN=jobsync-remote-bearer-token:latest
+            --set-secrets AIRTABLE_API_KEY=jobsync-airtable-api-key:latest,AIRTABLE_BASE_ID=jobsync-airtable-base-id:latest,JOBSYNC_REMOTE_BEARER_TOKEN=jobsync-remote-bearer-token:latest,ANTHROPIC_API_KEY=jobsync-anthropic-api-key:latest
 
       - name: Show Service URL
         run: |

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -56,4 +56,51 @@ export interface Run {
   agent: string;
   status: string;
   createdAt: string;
+  finishedAt?: string;
+  progress?: string[];
+  result?: { added: number; updated: number };
+  summary?: string;
+  error?: string;
+}
+
+export interface Roles {
+  detected: string[];
+  custom: string[];
+  excluded: string[];
+}
+
+export interface Personal {
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  phone?: string;
+  city?: string;
+  state?: string;
+  country?: string;
+  linkedinUrl?: string;
+  githubUrl?: string;
+  portfolioUrl?: string;
+}
+
+export interface Profile {
+  roles: Roles;
+  activeRoles: string[];
+  skills: string;
+  experience: string;
+  projects: string;
+  personal: Personal;
+  hasResume: boolean;
+}
+
+/** Read a File as base64 (no data: prefix). */
+export function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = String(reader.result);
+      resolve(result.slice(result.indexOf(",") + 1));
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
 }

--- a/dashboard/src/components/Agents.tsx
+++ b/dashboard/src/components/Agents.tsx
@@ -1,11 +1,12 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { apiFetch, type Agent, type Run } from "../api";
 
 export default function Agents() {
   const [agents, setAgents] = useState<Agent[]>([]);
   const [runs, setRuns] = useState<Run[]>([]);
-  const [notice, setNotice] = useState<string | null>(null);
+  const [active, setActive] = useState<Run | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const pollRef = useRef<number | null>(null);
 
   async function refresh() {
     try {
@@ -22,18 +23,39 @@ export default function Agents() {
 
   useEffect(() => {
     refresh();
+    return () => {
+      if (pollRef.current) window.clearInterval(pollRef.current);
+    };
   }, []);
 
+  function pollRun(id: string) {
+    if (pollRef.current) window.clearInterval(pollRef.current);
+    pollRef.current = window.setInterval(async () => {
+      try {
+        const run = await apiFetch<Run>(`/api/runs/${encodeURIComponent(id)}`);
+        setActive(run);
+        if (run.status === "succeeded" || run.status === "failed") {
+          if (pollRef.current) window.clearInterval(pollRef.current);
+          pollRef.current = null;
+          await refresh();
+        }
+      } catch {
+        /* keep polling */
+      }
+    }, 2500);
+  }
+
   async function run(agentId: string) {
-    setNotice(null);
     setError(null);
+    setActive(null);
     try {
-      const res = await apiFetch<{ message: string }>("/api/runs", {
+      const res = await apiFetch<{ run: Run; message?: string }>("/api/runs", {
         method: "POST",
-        body: JSON.stringify({ agent: agentId }),
+        body: JSON.stringify({ agent: agentId, params: { lookbackHours: 48 } }),
       });
-      setNotice(res.message);
-      await refresh();
+      setActive(res.run);
+      if (res.run.status === "running") pollRun(res.run.id);
+      else await refresh();
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     }
@@ -42,9 +64,8 @@ export default function Agents() {
   return (
     <section>
       <h1>Agents</h1>
-      <p className="muted">Pick an agent to run. Search finds jobs for you; Auto-Apply submits applications.</p>
+      <p className="muted">Pick an agent to run. Search finds jobs for you and fills your pipeline.</p>
 
-      {notice && <p className="notice">{notice}</p>}
       {error && <p className="error">{error}</p>}
 
       <div className="cards">
@@ -52,13 +73,38 @@ export default function Agents() {
           <div className="card agent-card" key={a.id}>
             <div className="agent-head">
               <h3>{a.name}</h3>
-              {a.status === "coming-soon" && <span className="badge">coming soon</span>}
+              {a.status !== "available" && <span className="badge">{a.status}</span>}
             </div>
             <p className="muted">{a.description}</p>
-            <button onClick={() => run(a.id)}>Run {a.name}</button>
+            <button onClick={() => run(a.id)} disabled={a.status === "unavailable"}>
+              Run {a.name}
+            </button>
           </div>
         ))}
       </div>
+
+      {active && (
+        <div className="card run-panel">
+          <div className="agent-head">
+            <h3>Search run</h3>
+            <span className="badge">{active.status}</span>
+          </div>
+          {active.status === "running" && active.progress && active.progress.length > 0 && (
+            <ul className="progress">
+              {active.progress.slice(-8).map((p, i) => (
+                <li key={i} className="muted small">{p}</li>
+              ))}
+            </ul>
+          )}
+          {active.status === "succeeded" && (
+            <p className="notice">
+              Added {active.result?.added ?? 0} job{active.result?.added === 1 ? "" : "s"}
+              {active.result?.updated ? `, updated ${active.result.updated}` : ""}. {active.summary}
+            </p>
+          )}
+          {active.status === "failed" && <p className="error">{active.error}</p>}
+        </div>
+      )}
 
       <h2>Recent runs</h2>
       {runs.length === 0 ? (
@@ -69,16 +115,16 @@ export default function Agents() {
             <tr>
               <th>Agent</th>
               <th>Status</th>
-              <th>Requested</th>
+              <th>Result</th>
+              <th>When</th>
             </tr>
           </thead>
           <tbody>
             {runs.map((r) => (
               <tr key={r.id}>
                 <td>{r.agent}</td>
-                <td>
-                  <span className="badge">{r.status}</span>
-                </td>
+                <td><span className="badge">{r.status}</span></td>
+                <td className="muted">{r.result ? `+${r.result.added}` : r.error ? "error" : "—"}</td>
                 <td className="muted">{new Date(r.createdAt).toLocaleString()}</td>
               </tr>
             ))}

--- a/dashboard/src/components/Profile.tsx
+++ b/dashboard/src/components/Profile.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useState, type ChangeEvent } from "react";
+import { apiFetch, fileToBase64, type Personal, type Profile as ProfileT } from "../api";
+
+export default function Profile() {
+  const [profile, setProfile] = useState<ProfileT | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [rolesText, setRolesText] = useState("");
+  const [personal, setPersonal] = useState<Personal>({});
+
+  async function load() {
+    try {
+      const p = await apiFetch<ProfileT>("/api/profile");
+      setProfile(p);
+      setRolesText(p.activeRoles.join(", "));
+      setPersonal(p.personal ?? {});
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function onResume(e: ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const base64 = await fileToBase64(file);
+      const p = await apiFetch<ProfileT>("/api/profile/resume", {
+        method: "POST",
+        body: JSON.stringify({ filename: file.name, base64 }),
+      });
+      setProfile(p);
+      setRolesText(p.activeRoles.join(", "));
+      setNotice("Resume parsed — review your roles and skills below.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setUploading(false);
+      e.target.value = "";
+    }
+  }
+
+  async function save() {
+    setError(null);
+    setNotice(null);
+    try {
+      const roles = rolesText.split(",").map((r) => r.trim()).filter(Boolean);
+      const p = await apiFetch<ProfileT>("/api/profile", {
+        method: "PUT",
+        body: JSON.stringify({ roles, personal, skills: profile?.skills }),
+      });
+      setProfile(p);
+      setNotice("Saved.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  if (!profile && !error) return <p className="muted">Loading profile…</p>;
+
+  const field = (key: keyof Personal, label: string) => (
+    <label>
+      {label}
+      <input
+        value={personal[key] ?? ""}
+        onChange={(e) => setPersonal({ ...personal, [key]: e.target.value })}
+      />
+    </label>
+  );
+
+  return (
+    <section>
+      <h1>Profile</h1>
+      <p className="muted">
+        Upload your resume — JobSync structures it into target roles and skills that drive the Search agent.
+      </p>
+
+      {notice && <p className="notice">{notice}</p>}
+      {error && <p className="error">{error}</p>}
+
+      <div className="card" style={{ marginBottom: 20 }}>
+        <h3>Resume</h3>
+        <p className="muted">{profile?.hasResume ? "A resume is on file." : "No resume uploaded yet."}</p>
+        <label className="file-btn">
+          {uploading ? "Parsing…" : "Upload resume (PDF / DOCX / TXT)"}
+          <input type="file" accept=".pdf,.docx,.txt,.md" onChange={onResume} disabled={uploading} hidden />
+        </label>
+      </div>
+
+      <div className="card" style={{ marginBottom: 20 }}>
+        <h3>Target roles</h3>
+        <p className="muted">Comma-separated. The Search agent looks for these.</p>
+        <input value={rolesText} onChange={(e) => setRolesText(e.target.value)} placeholder="Backend Engineer, ML Engineer" />
+      </div>
+
+      {profile?.skills && (
+        <div className="card" style={{ marginBottom: 20 }}>
+          <h3>Skills</h3>
+          <pre className="muted skills-pre">{profile.skills}</pre>
+        </div>
+      )}
+
+      <div className="card" style={{ marginBottom: 20 }}>
+        <h3>Contact (used for auto-apply later)</h3>
+        <div className="grid2">
+          {field("firstName", "First name")}
+          {field("lastName", "Last name")}
+          {field("email", "Email")}
+          {field("phone", "Phone")}
+          {field("city", "City")}
+          {field("state", "State")}
+          {field("linkedinUrl", "LinkedIn URL")}
+          {field("githubUrl", "GitHub URL")}
+        </div>
+      </div>
+
+      <button onClick={save}>Save profile</button>
+    </section>
+  );
+}

--- a/dashboard/src/pages/Dashboard.tsx
+++ b/dashboard/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "../auth";
 import { apiFetch } from "../api";
 import Agents from "../components/Agents";
 import Pipeline from "../components/Pipeline";
+import Profile from "../components/Profile";
 
 export default function Dashboard() {
   const { user, logout } = useAuth();
@@ -24,6 +25,7 @@ export default function Dashboard() {
         <nav>
           <NavLink to="/agents">Agents</NavLink>
           <NavLink to="/pipeline">Pipeline</NavLink>
+          <NavLink to="/profile">Profile</NavLink>
         </nav>
         <div className="sidebar-footer">
           <div className="muted email">{user?.email}</div>
@@ -41,6 +43,7 @@ export default function Dashboard() {
           <Routes>
             <Route path="/agents" element={<Agents />} />
             <Route path="/pipeline" element={<Pipeline />} />
+            <Route path="/profile" element={<Profile />} />
             <Route path="*" element={<Navigate to="/agents" replace />} />
           </Routes>
         )}

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -137,3 +137,32 @@ button.link {
   padding: 4px 6px;
   font-size: 12px;
 }
+
+/* Profile */
+.card h3 { margin-top: 0; }
+.card input {
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 9px 11px;
+  color: var(--text);
+  font-size: 14px;
+  width: 100%;
+}
+.grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.grid2 label { display: flex; flex-direction: column; gap: 4px; font-size: 13px; color: var(--muted); }
+.skills-pre { white-space: pre-wrap; font-family: inherit; margin: 0; }
+.file-btn {
+  display: inline-block;
+  background: var(--accent);
+  color: #1a0f0e;
+  border-radius: 8px;
+  padding: 9px 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+/* Run panel */
+.run-panel { margin: 18px 0 28px; }
+.progress { margin: 8px 0 0; padding-left: 18px; }
+.progress li { list-style: none; }

--- a/gcp-deploy.sh
+++ b/gcp-deploy.sh
@@ -58,6 +58,8 @@ gcloud run deploy "$SERVICE_NAME" \
   --region "$REGION" \
   --allow-unauthenticated \
   --memory 2Gi \
+  --no-cpu-throttling \
+  --timeout 900 \
   --set-env-vars="JOBSYNC_HEADLESS=true,NODE_ENV=production,JOBSYNC_STORAGE_BACKEND=firestore,GOOGLE_CLOUD_PROJECT=$PROJECT_ID,JOBSYNC_SINK=elasticsearch,JOBSYNC_ES_URL=https://job-hunt-elasticsearch-274835708611.us-east1.run.app,JOBSYNC_ES_INDEX=jobs_v2,JOBSYNC_ES_EMBEDDINGS=true"
 
 echo "=========================================================="
@@ -69,4 +71,6 @@ echo "  - JOBSYNC_REMOTE_BEARER_TOKEN : The bearer token to authorize API reques
 echo "  - GCS_BUCKET_NAME             : (Optional) The GCS bucket name to store screenshots"
 echo "  - AIRTABLE_API_KEY            : Your Airtable API Key"
 echo "  - AIRTABLE_BASE_ID            : Your Airtable Base ID"
+echo "  - ANTHROPIC_API_KEY          : Anthropic key for the server-side Search agent"
+echo "  - FIREBASE_API_KEY           : Firebase web apiKey for the dashboard"
 echo "=========================================================="

--- a/gcp.env.example.yaml
+++ b/gcp.env.example.yaml
@@ -7,8 +7,11 @@ JOBSYNC_ES_EMBEDDINGS: "true"
 AIRTABLE_TABLE_NAME: "Jobs"
 JOBSYNC_LOOKBACK_HOURS: "24"
 JOBSYNC_US_ONLY: "true"
-JOBSYNC_ENABLE_FAST_PATH: "false"
+JOBSYNC_ENABLE_FAST_PATH: "true"
 JOBSYNC_BRANDED_OUTPUT: "true"
+# Server-side Search agent. ANTHROPIC_API_KEY is injected as a secret (not here).
+# Model configurable; defaults to claude-sonnet-4-6.
+JOBSYNC_AGENT_MODEL: "claude-sonnet-4-6"
 # Persist cache + app state in Firestore (Cloud Run's filesystem is ephemeral).
 # projectId is auto-detected from the runtime's ADC; set FIRESTORE_DATABASE_ID
 # only if you use a non-default database.

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -27,6 +27,7 @@
     "node": ">=22.5.0"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.71.0",
     "@modelcontextprotocol/sdk": "^1.0.4",
     "cheerio": "^1.0.0",
     "mammoth": "^1.8.0",

--- a/mcp-server/src/api/dashboard.ts
+++ b/mcp-server/src/api/dashboard.ts
@@ -1,12 +1,29 @@
 // Dashboard REST API (/api/* — distinct from the /api/auto-apply browser routes
 // in http.ts). Every route except /api/config requires a valid Firebase ID token;
 // the uid is taken from the verified token and all data is scoped to it, so users
-// can only ever see their own pipeline and runs.
+// can only ever see their own profile, pipeline, and runs.
 
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { AuthError, requireUser, upsertUser, type AuthUser } from "../lib/firebase-auth.js";
 import { getPipelineGrouped, updateStatuses, type ApplicationStatus } from "../lib/pipeline.js";
+import {
+  activeRoles,
+  readProfileFile,
+  readRawResume,
+  readRoles,
+  writeProfileFile,
+  writeRawResume,
+  writeRoles,
+} from "../lib/profile.js";
+import { readPersonalProfile, writePersonalProfile, type PersonalProfile } from "../lib/personal-profile.js";
+import { parseResume } from "../lib/resume-parser.js";
+import { structureResume } from "../lib/profile-extract.js";
+import { isAgentConfigured } from "../lib/agent/anthropic.js";
+import { runSearchAgent, type SearchParams } from "../lib/agent/search-agent.js";
 import { getStore } from "../lib/store/index.js";
 
 function sendJson(res: ServerResponse, status: number, body: unknown): void {
@@ -14,7 +31,7 @@ function sendJson(res: ServerResponse, status: number, body: unknown): void {
     "content-type": "application/json",
     "access-control-allow-origin": "*",
     "access-control-allow-headers": "authorization, content-type",
-    "access-control-allow-methods": "GET, POST, PATCH, OPTIONS",
+    "access-control-allow-methods": "GET, POST, PATCH, PUT, OPTIONS",
   });
   res.end(JSON.stringify(body));
 }
@@ -46,36 +63,123 @@ function firebaseWebConfig() {
   };
 }
 
-const AGENT_CATALOG = [
-  {
-    id: "search",
-    name: "Search",
-    description: "Find and rank jobs matching your profile, then add them to your pipeline.",
-    status: "coming-soon",
-  },
-  {
-    id: "auto-apply",
-    name: "Auto-Apply",
-    description: "Automatically fill and submit applications for jobs in your pipeline.",
-    status: "coming-soon",
-  },
-];
+function agentCatalog() {
+  const searchReady = isAgentConfigured();
+  return [
+    {
+      id: "search",
+      name: "Search",
+      description: "Find and rank jobs matching your profile, then add them to your pipeline.",
+      status: searchReady ? "available" : "unavailable",
+    },
+    {
+      id: "auto-apply",
+      name: "Auto-Apply",
+      description: "Automatically fill and submit applications for jobs in your pipeline.",
+      status: "coming-soon",
+    },
+  ];
+}
+
+// ── Run lifecycle ─────────────────────────────────────────────────────────────
+
+type RunStatus = "queued" | "running" | "succeeded" | "failed";
 
 interface RunRecord {
   id: string;
   agent: string;
   params: Record<string, unknown>;
-  status: string;
+  status: RunStatus;
   createdAt: string;
+  finishedAt?: string;
+  progress?: string[];
+  result?: { added: number; updated: number };
+  summary?: string;
+  error?: string;
 }
+
+// Live, in-memory view of in-flight runs (updated as the agent streams progress);
+// persisted to the docs store on start + finish. GET overlays live over persisted.
+const liveRuns = new Map<string, RunRecord>();
+const activeByUid = new Map<string, string>();
 
 async function readRuns(uid: string): Promise<RunRecord[]> {
   const raw = await (await getStore()).docs.readDoc("runs", uid);
   return raw ? (JSON.parse(raw) as RunRecord[]) : [];
 }
 
-async function writeRuns(uid: string, runs: RunRecord[]): Promise<void> {
-  await (await getStore()).docs.writeDoc("runs", uid, JSON.stringify(runs));
+async function persistRun(uid: string, run: RunRecord): Promise<void> {
+  const runs = await readRuns(uid);
+  const i = runs.findIndex((r) => r.id === run.id);
+  if (i >= 0) runs[i] = run;
+  else runs.unshift(run);
+  await (await getStore()).docs.writeDoc("runs", uid, JSON.stringify(runs.slice(0, 100)));
+}
+
+/** Kick off a Search agent run in the background. Returns the initial record. */
+function startSearchRun(uid: string, params: SearchParams): RunRecord {
+  const run: RunRecord = {
+    id: randomUUID(),
+    agent: "search",
+    params: params as Record<string, unknown>,
+    status: "running",
+    createdAt: new Date().toISOString(),
+    progress: [],
+  };
+  liveRuns.set(run.id, run);
+  activeByUid.set(uid, run.id);
+  void persistRun(uid, run).catch(() => {});
+
+  runSearchAgent(uid, params, (msg) => {
+    run.progress!.push(msg);
+    if (run.progress!.length > 30) run.progress!.shift();
+  })
+    .then((result) => {
+      run.status = "succeeded";
+      run.result = { added: result.added, updated: result.updated };
+      run.summary = result.summary;
+    })
+    .catch((err: unknown) => {
+      run.status = "failed";
+      run.error = err instanceof Error ? err.message : String(err);
+    })
+    .finally(() => {
+      run.finishedAt = new Date().toISOString();
+      activeByUid.delete(uid);
+      void persistRun(uid, run).catch(() => {});
+      // Keep the finished record live for a few minutes so the UI can read the result.
+      setTimeout(() => liveRuns.delete(run.id), 5 * 60 * 1000).unref?.();
+    });
+
+  return run;
+}
+
+/** Merge persisted runs with the live in-memory view (live wins). */
+async function listRuns(uid: string): Promise<RunRecord[]> {
+  const persisted = await readRuns(uid);
+  return persisted.map((r) => liveRuns.get(r.id) ?? r);
+}
+
+// ── Profile ───────────────────────────────────────────────────────────────────
+
+async function getProfile(uid: string) {
+  const [roles, skills, experience, projects, personal, rawResume] = await Promise.all([
+    readRoles(uid),
+    readProfileFile("skills", uid),
+    readProfileFile("experience", uid),
+    readProfileFile("projects", uid),
+    readPersonalProfile(uid),
+    readRawResume(uid),
+  ]);
+  return {
+    roles,
+    activeRoles: activeRoles(roles),
+    skills,
+    experience,
+    projects,
+    personal,
+    hasResume: rawResume.length > 0,
+  };
 }
 
 /**
@@ -88,12 +192,10 @@ export async function handleDashboardApi(
   pathname: string,
 ): Promise<boolean> {
   if (!pathname.startsWith("/api/")) return false;
-  // /api/auto-apply/* is handled separately in http.ts.
-  if (pathname.startsWith("/api/auto-apply")) return false;
+  if (pathname.startsWith("/api/auto-apply")) return false; // handled in http.ts
 
   const method = req.method ?? "GET";
 
-  // Public: SPA bootstrap config.
   if (pathname === "/api/config" && method === "GET") {
     sendJson(res, 200, firebaseWebConfig());
     return true;
@@ -111,26 +213,82 @@ export async function handleDashboardApi(
     sendJson(res, 500, { error: err instanceof Error ? err.message : String(err) });
     return true;
   }
+  const uid = user.uid;
 
   try {
     if (pathname === "/api/me" && method === "GET") {
       await upsertUser(user);
-      sendJson(res, 200, { uid: user.uid, email: user.email });
+      sendJson(res, 200, { uid, email: user.email });
       return true;
     }
 
     if (pathname === "/api/agents" && method === "GET") {
-      sendJson(res, 200, { agents: AGENT_CATALOG });
+      sendJson(res, 200, { agents: agentCatalog() });
       return true;
     }
 
+    // ── Profile ──
+    if (pathname === "/api/profile" && method === "GET") {
+      sendJson(res, 200, await getProfile(uid));
+      return true;
+    }
+
+    if (pathname === "/api/profile" && method === "PUT") {
+      const body = await readJsonBody(req);
+      if (Array.isArray(body.roles)) {
+        const r = await readRoles(uid);
+        await writeRoles({ ...r, custom: (body.roles as string[]).map(String) }, uid);
+      }
+      if (typeof body.skills === "string") await writeProfileFile("skills", body.skills, uid);
+      if (typeof body.experience === "string") await writeProfileFile("experience", body.experience, uid);
+      if (typeof body.projects === "string") await writeProfileFile("projects", body.projects, uid);
+      if (body.personal && typeof body.personal === "object") {
+        await writePersonalProfile(body.personal as Partial<PersonalProfile>, uid);
+      }
+      sendJson(res, 200, await getProfile(uid));
+      return true;
+    }
+
+    // POST /api/profile/resume — base64 resume → parse → structure → store (scoped)
+    if (pathname === "/api/profile/resume" && method === "POST") {
+      if (!isAgentConfigured()) {
+        sendJson(res, 503, { error: "Resume structuring needs ANTHROPIC_API_KEY (not configured)." });
+        return true;
+      }
+      const body = await readJsonBody(req);
+      const base64 = String(body.base64 ?? "");
+      const filename = String(body.filename ?? "resume.pdf");
+      if (!base64) {
+        sendJson(res, 400, { error: "base64 file content is required" });
+        return true;
+      }
+      const dir = join(tmpdir(), `jobsync-resume-${randomUUID()}`);
+      const path = join(dir, filename.replace(/[^\w.\-]/g, "_"));
+      try {
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(path, Buffer.from(base64, "base64"));
+        const text = await parseResume(path);
+        await writeRawResume(text, uid);
+        const structured = await structureResume(text);
+        await Promise.all([
+          writeRoles({ detected: structured.roles, custom: [], excluded: [] }, uid),
+          writeProfileFile("skills", structured.skills.map((s) => `- ${s}`).join("\n"), uid),
+          writeProfileFile("experience", structured.experience, uid),
+          writeProfileFile("projects", structured.projects, uid),
+        ]);
+        sendJson(res, 200, { ok: true, chars: text.length, ...(await getProfile(uid)) });
+      } finally {
+        if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+      }
+      return true;
+    }
+
+    // ── Pipeline ──
     if (pathname === "/api/pipeline" && method === "GET") {
-      const result = await getPipelineGrouped(undefined, user.uid);
-      sendJson(res, 200, result);
+      sendJson(res, 200, await getPipelineGrouped(undefined, uid));
       return true;
     }
 
-    // PATCH /api/pipeline/:id  → update one tracked job's status/notes
     if (pathname.startsWith("/api/pipeline/") && method === "PATCH") {
       const id = decodeURIComponent(pathname.slice("/api/pipeline/".length));
       const body = await readJsonBody(req);
@@ -139,42 +297,66 @@ export async function handleDashboardApi(
         sendJson(res, 400, { error: "status is required" });
         return true;
       }
-      const result = await updateStatuses(
-        [{ id, status, notes: body.notes as string | undefined }],
-        user.uid,
-      );
+      const result = await updateStatuses([{ id, status, notes: body.notes as string | undefined }], uid);
       sendJson(res, result.matched > 0 ? 200 : 404, result);
       return true;
     }
 
+    // ── Runs ──
     if (pathname === "/api/runs" && method === "GET") {
-      sendJson(res, 200, { runs: await readRuns(user.uid) });
+      sendJson(res, 200, { runs: await listRuns(uid) });
       return true;
     }
 
-    // POST /api/runs → record an agent-run request. Phase 1 only queues it;
-    // the server-side agent runtime (Search/Auto-Apply) ships in Phase 2/3.
+    // GET /api/runs/:id — live status of a single run
+    if (pathname.startsWith("/api/runs/") && method === "GET") {
+      const id = decodeURIComponent(pathname.slice("/api/runs/".length));
+      const run = liveRuns.get(id) ?? (await readRuns(uid)).find((r) => r.id === id);
+      if (!run) {
+        sendJson(res, 404, { error: "run not found" });
+        return true;
+      }
+      sendJson(res, 200, run);
+      return true;
+    }
+
     if (pathname === "/api/runs" && method === "POST") {
       const body = await readJsonBody(req);
       const agent = String(body.agent ?? "");
-      if (!AGENT_CATALOG.some((a) => a.id === agent)) {
-        sendJson(res, 400, { error: `unknown agent: ${agent}` });
+      const params = (body.params as Record<string, unknown>) ?? {};
+
+      if (agent === "search") {
+        if (!isAgentConfigured()) {
+          sendJson(res, 503, { error: "Search agent is not configured (ANTHROPIC_API_KEY missing)." });
+          return true;
+        }
+        if (activeByUid.has(uid)) {
+          sendJson(res, 409, { error: "A search is already running. Wait for it to finish." });
+          return true;
+        }
+        const run = startSearchRun(uid, {
+          lookbackHours: typeof params.lookbackHours === "number" ? params.lookbackHours : undefined,
+          roles: Array.isArray(params.roles) ? (params.roles as string[]) : undefined,
+          companies: Array.isArray(params.companies) ? (params.companies as string[]) : undefined,
+        });
+        sendJson(res, 202, { run });
         return true;
       }
-      const run: RunRecord = {
-        id: randomUUID(),
-        agent,
-        params: (body.params as Record<string, unknown>) ?? {},
-        status: "queued",
-        createdAt: new Date().toISOString(),
-      };
-      const runs = await readRuns(user.uid);
-      runs.unshift(run);
-      await writeRuns(user.uid, runs.slice(0, 100));
-      sendJson(res, 202, {
-        run,
-        message: "Queued. The agent runtime ships in the next release — your request is saved.",
-      });
+
+      if (agent === "auto-apply") {
+        const run: RunRecord = {
+          id: randomUUID(),
+          agent,
+          params,
+          status: "queued",
+          createdAt: new Date().toISOString(),
+        };
+        await persistRun(uid, run);
+        sendJson(res, 202, { run, message: "Auto-Apply ships in the next release — your request is saved." });
+        return true;
+      }
+
+      sendJson(res, 400, { error: `unknown agent: ${agent}` });
       return true;
     }
 

--- a/mcp-server/src/lib/agent/anthropic.ts
+++ b/mcp-server/src/lib/agent/anthropic.ts
@@ -1,0 +1,32 @@
+// Anthropic client for the server-side agent runtime. One shared deployment key
+// (ANTHROPIC_API_KEY); the model is configurable via JOBSYNC_AGENT_MODEL and
+// defaults to claude-sonnet-4-6 (cheaper/faster for the high-volume scrape loop).
+// Lazily imported so installs that never run an agent don't pay the dependency.
+
+import type Anthropic from "@anthropic-ai/sdk";
+
+export const DEFAULT_AGENT_MODEL = "claude-sonnet-4-6";
+
+export function agentModel(): string {
+  return process.env.JOBSYNC_AGENT_MODEL ?? DEFAULT_AGENT_MODEL;
+}
+
+export function isAgentConfigured(): boolean {
+  return Boolean(process.env.ANTHROPIC_API_KEY);
+}
+
+let clientPromise: Promise<Anthropic> | null = null;
+
+export function getAnthropic(): Promise<Anthropic> {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return Promise.reject(
+      new Error("ANTHROPIC_API_KEY is not set — the Search agent runtime is unavailable."),
+    );
+  }
+  if (!clientPromise) {
+    clientPromise = import("@anthropic-ai/sdk").then(({ default: AnthropicCtor }) => {
+      return new AnthropicCtor({ apiKey: process.env.ANTHROPIC_API_KEY });
+    });
+  }
+  return clientPromise;
+}

--- a/mcp-server/src/lib/agent/search-agent.ts
+++ b/mcp-server/src/lib/agent/search-agent.ts
@@ -1,0 +1,146 @@
+// Server-side Search agent. Runs an autonomous Claude tool-use loop on behalf of
+// one user (scope = uid via run-context), using the jobsync tools + Anthropic
+// web_search to discover, vet, dedupe, and land jobs in the user's pipeline.
+
+import type Anthropic from "@anthropic-ai/sdk";
+import { runWithScope } from "../run-context.js";
+import { agentModel, getAnthropic } from "./anthropic.js";
+import { buildToolBridge, runBridgedTool, SEARCH_AGENT_TOOLS } from "./tools-bridge.js";
+
+export interface SearchParams {
+  lookbackHours?: number;
+  /** Role keywords to target; overrides/augments the user's profile roles. */
+  roles?: string[];
+  /** Known company ATS slugs to pull directly (greenhouse/lever/ashby). */
+  companies?: string[];
+}
+
+export interface SearchResult {
+  added: number;
+  updated: number;
+  iterations: number;
+  summary: string;
+}
+
+const MAX_ITERATIONS = 40;
+const MAX_TOKENS = 16000;
+
+const SYSTEM_PROMPT = `You are JobSync's autonomous job-search agent, running server-side for ONE user.
+Your goal: find RECENT, RELEVANT job postings matching the user's profile, vet them, dedupe against what they've already seen, and add the new ones to THEIR pipeline.
+
+Workflow:
+1. Call profile_read to load the user's skills, experience, and activeRoles. If activeRoles is empty, infer target roles from their skills/experience and any roles passed in the kickoff.
+2. Optionally call portals_read for the user's configured company boards.
+3. Discover postings:
+   - For known company ATS slugs, use fetch_greenhouse_jobs / fetch_lever_jobs / fetch_ashby_jobs / fetch_workday_jobs.
+   - Use web_search for broader discovery (e.g. site:job-boards.greenhouse.io <role>, site:jobs.lever.co <role>) when you need more candidates.
+4. Enrich + filter each candidate: scrape_job_details (jobDescription, datePosted, salary), then filter_us_location and filter_title_keywords to drop irrelevant roles, classify_job_batch / detect_industry_tags to tag and score fit. Keep only jobs posted within the lookback window.
+5. Verify links with verify_job_link_batch and drop dead ones.
+6. Dedupe: cache_is_seen on the apply links; for misses also elasticsearch_list_recent_jobs to reconcile. Skip anything already seen.
+7. Add the new, vetted jobs with pipeline_upsert_jobs — they land in this user's pipeline. Then cache_mark_seen for those jobs.
+8. Finish with a concise one-paragraph summary: how many jobs you added and the notable companies/roles.
+
+Rules:
+- Only include jobs you VERIFIED are live and posted within the lookback window. Never fabricate postings or apply links.
+- Be efficient: batch tool calls, and cap the run at ~25 high-quality jobs.
+- When done, stop and give your summary — do not loop indefinitely.`;
+
+interface ProgressSink {
+  (message: string): void;
+}
+
+type ContentBlock = Anthropic.Messages.ContentBlock;
+type MessageParam = Anthropic.Messages.MessageParam;
+
+/** Accumulate added/updated counts from pipeline_upsert_jobs tool outputs. */
+function tallyUpsert(text: string, tally: { added: number; updated: number }): void {
+  try {
+    const parsed = JSON.parse(text) as { added?: number; updated?: number };
+    if (typeof parsed.added === "number") tally.added += parsed.added;
+    if (typeof parsed.updated === "number") tally.updated += parsed.updated;
+  } catch {
+    /* non-JSON output — ignore */
+  }
+}
+
+export async function runSearchAgent(
+  uid: string,
+  params: SearchParams,
+  onProgress: ProgressSink = () => {},
+): Promise<SearchResult> {
+  return runWithScope(uid, async () => {
+    const client = await getAnthropic();
+    const bridge = buildToolBridge(SEARCH_AGENT_TOOLS);
+    const tally = { added: 0, updated: 0 };
+
+    const lookbackHours = params.lookbackHours ?? 48;
+    const kickoff =
+      `Run a job search for me now. lookbackHours=${lookbackHours}.` +
+      (params.roles?.length ? ` Target roles: ${params.roles.join(", ")}.` : "") +
+      (params.companies?.length ? ` Known company slugs to pull: ${params.companies.join(", ")}.` : "") +
+      ` Add the new, vetted jobs to my pipeline and summarize what you found.`;
+
+    const tools = [
+      ...bridge.tools,
+      // Anthropic server tool — discovery via web search (run on Anthropic's side).
+      { type: "web_search_20260209", name: "web_search" },
+    ] as unknown as Anthropic.Messages.ToolUnion[];
+
+    const messages: MessageParam[] = [{ role: "user", content: kickoff }];
+    let finalText = "";
+    let iterations = 0;
+
+    while (iterations < MAX_ITERATIONS) {
+      iterations++;
+      const resp = await client.messages.create({
+        model: agentModel(),
+        max_tokens: MAX_TOKENS,
+        system: SYSTEM_PROMPT,
+        tools,
+        messages,
+      });
+
+      messages.push({ role: "assistant", content: resp.content });
+
+      // Surface any text the model emitted this turn as progress.
+      const turnText = (resp.content as ContentBlock[])
+        .filter((b): b is Anthropic.Messages.TextBlock => b.type === "text")
+        .map((b) => b.text)
+        .join(" ")
+        .trim();
+      if (turnText) {
+        finalText = turnText;
+        onProgress(turnText.slice(0, 300));
+      }
+
+      if (resp.stop_reason === "end_turn") break;
+      // Server tool (web_search) hit its internal loop limit — re-send to resume.
+      if (resp.stop_reason === "pause_turn") continue;
+
+      if (resp.stop_reason === "tool_use") {
+        const toolUses = (resp.content as ContentBlock[]).filter(
+          (b): b is Anthropic.Messages.ToolUseBlock => b.type === "tool_use",
+        );
+        const results: Anthropic.Messages.ToolResultBlockParam[] = [];
+        for (const use of toolUses) {
+          onProgress(`→ ${use.name}`);
+          const run = await runBridgedTool(bridge, use.name, use.input as Record<string, unknown>);
+          if (use.name === "pipeline_upsert_jobs" && !run.isError) tallyUpsert(run.text, tally);
+          results.push({
+            type: "tool_result",
+            tool_use_id: use.id,
+            content: run.text.slice(0, 60000),
+            is_error: run.isError,
+          });
+        }
+        messages.push({ role: "user", content: results });
+        continue;
+      }
+
+      // refusal / max_tokens / unknown — stop.
+      break;
+    }
+
+    return { added: tally.added, updated: tally.updated, iterations, summary: finalText };
+  });
+}

--- a/mcp-server/src/lib/agent/tools-bridge.test.ts
+++ b/mcp-server/src/lib/agent/tools-bridge.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { runBridgedTool, type ToolBridge } from "./tools-bridge.js";
+
+function bridgeWith(handlers: ToolBridge["handlers"]): ToolBridge {
+  return { tools: [], handlers };
+}
+
+describe("runBridgedTool", () => {
+  it("dispatches to the handler and flattens text blocks", async () => {
+    const bridge = bridgeWith(
+      new Map([
+        ["echo", async (args: Record<string, unknown>) => ({
+          content: [{ type: "text" as const, text: `got ${args.x}` }],
+        })],
+      ]),
+    );
+    const result = await runBridgedTool(bridge, "echo", { x: 42 });
+    expect(result).toEqual({ text: "got 42", isError: false });
+  });
+
+  it("reports unknown tools as errors", async () => {
+    const result = await runBridgedTool(bridgeWith(new Map()), "missing", {});
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain("Unknown tool");
+  });
+
+  it("propagates a handler's isError flag", async () => {
+    const bridge = bridgeWith(
+      new Map([
+        ["bad", async () => ({ content: [{ type: "text" as const, text: "nope" }], isError: true })],
+      ]),
+    );
+    expect(await runBridgedTool(bridge, "bad", {})).toEqual({ text: "nope", isError: true });
+  });
+
+  it("catches handler exceptions", async () => {
+    const bridge = bridgeWith(
+      new Map([["boom", async () => { throw new Error("kaboom"); }]]),
+    );
+    const result = await runBridgedTool(bridge, "boom", {});
+    expect(result.isError).toBe(true);
+    expect(result.text).toBe("kaboom");
+  });
+});

--- a/mcp-server/src/lib/agent/tools-bridge.ts
+++ b/mcp-server/src/lib/agent/tools-bridge.ts
@@ -1,0 +1,88 @@
+// Bridges jobsync's MCP tool registry to Anthropic custom tools so the
+// server-side agent can call them in a Messages API loop. The same
+// ToolDefinition.handler implementations run; we just translate the schema and
+// flatten the ToolResult into text for the model.
+
+import { registerTools, type ToolDefinition } from "../../tools/index.js";
+
+export interface AgentTool {
+  name: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+}
+
+export interface ToolBridge {
+  tools: AgentTool[];
+  handlers: Map<string, ToolDefinition["handler"]>;
+}
+
+// Tools the Search agent is allowed to call. Deliberately excludes the
+// auto-apply/browser tools and Airtable writes — Search only discovers, vets,
+// dedupes, and lands jobs in the user's pipeline (+ optional ES index).
+export const SEARCH_AGENT_TOOLS = [
+  "jobsync_ping",
+  "profile_read",
+  "portals_read",
+  "filter_us_location",
+  "filter_title_keywords",
+  "detect_industry_tags",
+  "classify_job_batch",
+  "fetch_greenhouse_jobs",
+  "fetch_lever_jobs",
+  "fetch_ashby_jobs",
+  "fetch_workday_jobs",
+  "ashby_get_date_posted_batch",
+  "scrape_job_details",
+  "verify_job_link",
+  "verify_job_link_batch",
+  "elasticsearch_index_jobs",
+  "elasticsearch_list_recent_jobs",
+  "cache_is_seen",
+  "cache_mark_seen",
+  "pipeline_upsert_jobs",
+] as const;
+
+/** Build the Anthropic tool list + handler map for the given allowlist. */
+export function buildToolBridge(allowed: readonly string[]): ToolBridge {
+  const allowSet = new Set(allowed);
+  const tools: AgentTool[] = [];
+  const handlers = new Map<string, ToolDefinition["handler"]>();
+
+  for (const def of registerTools()) {
+    if (!allowSet.has(def.name)) continue;
+    tools.push({
+      name: def.name,
+      // Anthropic caps tool descriptions; keep them tight.
+      description: def.description.slice(0, 1024),
+      input_schema: def.inputSchema as Record<string, unknown>,
+    });
+    handlers.set(def.name, def.handler);
+  }
+  return { tools, handlers };
+}
+
+export interface ToolRunResult {
+  text: string;
+  isError: boolean;
+}
+
+/** Execute a bridged tool by name and flatten its ToolResult to text. */
+export async function runBridgedTool(
+  bridge: ToolBridge,
+  name: string,
+  input: Record<string, unknown>,
+): Promise<ToolRunResult> {
+  const handler = bridge.handlers.get(name);
+  if (!handler) return { text: `Unknown tool: ${name}`, isError: true };
+  try {
+    const result = await handler(input ?? {});
+    const text = result.content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text)
+      .join("\n")
+      .trim();
+    return { text: text || "(no output)", isError: Boolean(result.isError) };
+  } catch (err) {
+    return { text: err instanceof Error ? err.message : String(err), isError: true };
+  }
+}

--- a/mcp-server/src/lib/personal-profile.ts
+++ b/mcp-server/src/lib/personal-profile.ts
@@ -1,7 +1,17 @@
 import { getStore } from "./store/index.js";
+import { currentScope } from "./run-context.js";
 
 const NS = "profile";
-const ID = "personal.json";
+const FILE = "personal.json";
+
+function scopeDefault(): string {
+  return currentScope() ?? "default";
+}
+
+/** Per-user doc id; "default" keeps the historical bare name. */
+function docId(scope: string): string {
+  return scope === "default" ? FILE : `${scope}__${FILE}`;
+}
 
 export interface PersonalProfile {
   firstName: string;
@@ -32,8 +42,10 @@ export interface PersonalProfile {
   disabilityDetails: string;
 }
 
-export async function readPersonalProfile(): Promise<Partial<PersonalProfile>> {
-  const raw = await (await getStore()).docs.readDoc(NS, ID);
+export async function readPersonalProfile(
+  scope: string = scopeDefault(),
+): Promise<Partial<PersonalProfile>> {
+  const raw = await (await getStore()).docs.readDoc(NS, docId(scope));
   if (!raw) return {};
   try {
     return JSON.parse(raw) as Partial<PersonalProfile>;
@@ -42,9 +54,12 @@ export async function readPersonalProfile(): Promise<Partial<PersonalProfile>> {
   }
 }
 
-export async function writePersonalProfile(patch: Partial<PersonalProfile>): Promise<PersonalProfile> {
-  const existing = await readPersonalProfile();
+export async function writePersonalProfile(
+  patch: Partial<PersonalProfile>,
+  scope: string = scopeDefault(),
+): Promise<PersonalProfile> {
+  const existing = await readPersonalProfile(scope);
   const merged = { ...existing, ...patch } as PersonalProfile;
-  await (await getStore()).docs.writeDoc(NS, ID, JSON.stringify(merged, null, 2));
+  await (await getStore()).docs.writeDoc(NS, docId(scope), JSON.stringify(merged, null, 2));
   return merged;
 }

--- a/mcp-server/src/lib/pipeline.ts
+++ b/mcp-server/src/lib/pipeline.ts
@@ -1,10 +1,17 @@
 import { join } from "node:path";
 import { CONFIG_DIR } from "../config.js";
 import { getStore } from "./store/index.js";
+import { currentScope } from "./run-context.js";
 
 const NS = "pipeline";
-/** Default scope for the single-user (local/stdio) path. Multi-user callers pass a uid. */
-const DEFAULT_SCOPE = "default";
+/**
+ * Resolve the default pipeline scope: the ambient run uid when inside a scoped
+ * agent run, else "default" (the single-user local/stdio path). Explicit callers
+ * (the dashboard API) still pass a uid directly.
+ */
+function scopeDefault(): string {
+  return currentScope() ?? "default";
+}
 
 export type ApplicationStatus =
   | "pending"
@@ -49,7 +56,7 @@ function escape(value: string): string {
   return (value ?? "").replace(/[\t\n\r]/g, " ");
 }
 
-export async function readPipeline(scope: string = DEFAULT_SCOPE): Promise<PipelineEntry[]> {
+export async function readPipeline(scope: string = scopeDefault()): Promise<PipelineEntry[]> {
   const raw = await (await getStore()).docs.readDoc(NS, scope);
   if (!raw) return [];
 
@@ -64,7 +71,7 @@ export async function readPipeline(scope: string = DEFAULT_SCOPE): Promise<Pipel
   });
 }
 
-export async function writePipeline(entries: PipelineEntry[], scope: string = DEFAULT_SCOPE): Promise<void> {
+export async function writePipeline(entries: PipelineEntry[], scope: string = scopeDefault()): Promise<void> {
   const header = HEADERS.join("\t");
   const rows = entries.map((e) =>
     HEADERS.map((k) => escape((e as unknown as Record<string, string>)[k] ?? "")).join("\t")
@@ -75,7 +82,7 @@ export async function writePipeline(entries: PipelineEntry[], scope: string = DE
 
 export async function upsertPipelineEntries(
   incoming: Array<Partial<PipelineEntry> & { positionTitle: string; company: string; applyLink: string }>,
-  scope: string = DEFAULT_SCOPE,
+  scope: string = scopeDefault(),
 ): Promise<{ added: number; updated: number }> {
   const existing = await readPipeline(scope);
   const byId = new Map(existing.map((e) => [e.id, e]));
@@ -130,7 +137,7 @@ export async function upsertPipelineEntries(
 
 export async function markApplied(
   applyLinks: string[],
-  scope: string = DEFAULT_SCOPE,
+  scope: string = scopeDefault(),
 ): Promise<{ matched: number; notFound: string[] }> {
   const entries = await readPipeline(scope);
   const linkSet = new Set(applyLinks.map((l) => l.trim()));
@@ -153,7 +160,7 @@ export async function markApplied(
 
 export async function updateStatuses(
   updates: Array<{ applyLink?: string; id?: string; status: ApplicationStatus; notes?: string }>,
-  scope: string = DEFAULT_SCOPE,
+  scope: string = scopeDefault(),
 ): Promise<{ matched: number; invalid: string[] }> {
   const entries = await readPipeline(scope);
   const now = new Date().toISOString().slice(0, 10);
@@ -185,7 +192,7 @@ export async function updateStatuses(
 
 export async function getPipelineGrouped(
   statusFilter?: ApplicationStatus[],
-  scope: string = DEFAULT_SCOPE,
+  scope: string = scopeDefault(),
 ): Promise<{ summary: Record<string, number>; byStatus: Record<string, PipelineEntry[]> }> {
   const all = await readPipeline(scope);
   const entries = statusFilter

--- a/mcp-server/src/lib/profile-extract.ts
+++ b/mcp-server/src/lib/profile-extract.ts
@@ -1,0 +1,61 @@
+// Structure a raw resume into roles/skills/experience/projects via one Claude
+// call. This replaces the interactive MCP onboarding prompt for the self-serve
+// dashboard flow (where there's no MCP client to drive structuring).
+
+import type Anthropic from "@anthropic-ai/sdk";
+import { agentModel, getAnthropic } from "./agent/anthropic.js";
+
+export interface StructuredProfile {
+  roles: string[];
+  skills: string[];
+  experience: string;
+  projects: string;
+}
+
+const SCHEMA = {
+  type: "object",
+  properties: {
+    roles: {
+      type: "array",
+      items: { type: "string" },
+      description: "3-8 target job titles this candidate should apply to, e.g. 'Backend Engineer'.",
+    },
+    skills: { type: "array", items: { type: "string" }, description: "Key technical + domain skills." },
+    experience: { type: "string", description: "Concise markdown summary of work experience." },
+    projects: { type: "string", description: "Concise markdown summary of notable projects (may be empty)." },
+  },
+  required: ["roles", "skills", "experience", "projects"],
+  additionalProperties: false,
+} as const;
+
+const SYSTEM =
+  "You structure a candidate's resume into a job-search profile. Infer realistic target job titles (roles) from their experience and skills. Be faithful to the resume — do not invent experience.";
+
+export async function structureResume(rawText: string): Promise<StructuredProfile> {
+  const client = await getAnthropic();
+  const resp = await client.messages.create({
+    model: agentModel(),
+    max_tokens: 4000,
+    system: SYSTEM,
+    output_config: { format: { type: "json_schema", schema: SCHEMA } },
+    messages: [
+      {
+        role: "user",
+        content: `Structure this resume into the required JSON profile:\n\n${rawText.slice(0, 40000)}`,
+      },
+    ],
+  } as Anthropic.Messages.MessageCreateParamsNonStreaming);
+
+  const text = (resp.content as Anthropic.Messages.ContentBlock[])
+    .filter((b): b is Anthropic.Messages.TextBlock => b.type === "text")
+    .map((b) => b.text)
+    .join("");
+
+  const parsed = JSON.parse(text) as StructuredProfile;
+  return {
+    roles: parsed.roles ?? [],
+    skills: parsed.skills ?? [],
+    experience: parsed.experience ?? "",
+    projects: parsed.projects ?? "",
+  };
+}

--- a/mcp-server/src/lib/profile.test.ts
+++ b/mcp-server/src/lib/profile.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// In-memory docs store so profile scoping can be tested without SQLite/Firestore.
+const docs = new Map<string, string>();
+const key = (ns: string, id: string) => `${ns}::${id}`;
+
+vi.mock("./store/index.js", () => ({
+  getStore: async () => ({
+    backend: "local",
+    docs: {
+      async readDoc(ns: string, id: string) {
+        return docs.get(key(ns, id)) ?? null;
+      },
+      async writeDoc(ns: string, id: string, body: string) {
+        docs.set(key(ns, id), body);
+      },
+      async deleteDoc(ns: string, id: string) {
+        docs.delete(key(ns, id));
+      },
+      async listDocs() {
+        return [];
+      },
+    },
+  }),
+}));
+
+const { readRoles, writeRoles, readProfileFile, writeProfileFile } = await import("./profile.js");
+const { runWithScope } = await import("./run-context.js");
+
+beforeEach(() => docs.clear());
+
+describe("profile tenant isolation (scope = uid)", () => {
+  it("keeps each user's roles and skills separate", async () => {
+    await writeRoles({ detected: ["Backend Engineer"], custom: [], excluded: [] }, "userA");
+    await writeRoles({ detected: ["ML Engineer"], custom: [], excluded: [] }, "userB");
+    await writeProfileFile("skills", "Go, Postgres", "userA");
+
+    expect((await readRoles("userA")).detected).toEqual(["Backend Engineer"]);
+    expect((await readRoles("userB")).detected).toEqual(["ML Engineer"]);
+    expect(await readProfileFile("skills", "userA")).toBe("Go, Postgres");
+    expect(await readProfileFile("skills", "userB")).toBe(""); // not leaked
+  });
+
+  it("uses the historical bare key for the default scope", async () => {
+    await writeRoles({ detected: ["X"], custom: [], excluded: [] }, "default");
+    expect(docs.has("profile::roles.json")).toBe(true);
+    expect(docs.has("profile::default__roles.json")).toBe(false);
+  });
+});
+
+describe("run-context ambient scope", () => {
+  it("writes/reads under the run's uid when no explicit scope is passed", async () => {
+    await runWithScope("userZ", async () => {
+      await writeRoles({ detected: ["Zeta"], custom: [], excluded: [] });
+    });
+    // Stored under userZ, not default.
+    expect(docs.has("profile::userZ__roles.json")).toBe(true);
+    expect((await readRoles("userZ")).detected).toEqual(["Zeta"]);
+    expect((await readRoles("default")).detected).toEqual([]);
+  });
+});

--- a/mcp-server/src/lib/profile.ts
+++ b/mcp-server/src/lib/profile.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { getStorageConfig, loadConfig } from "../config.js";
 import { getStore } from "./store/index.js";
+import { currentScope } from "./run-context.js";
 
 export type ProfileFile = "skills" | "experience" | "projects";
 
@@ -18,6 +19,18 @@ export interface Roles {
 
 const EMPTY_ROLES: Roles = { detected: [], custom: [], excluded: [] };
 const NS = "profile";
+
+function scopeDefault(): string {
+  return currentScope() ?? "default";
+}
+
+/**
+ * Per-user doc id. "default" (single-user/stdio) keeps the historical bare file
+ * name; multi-user callers get a `<uid>__<name>` id so profiles are isolated.
+ */
+function docId(scope: string, name: string): string {
+  return scope === "default" ? name : `${scope}__${name}`;
+}
 
 function profileDir(): string {
   return loadConfig().profileDir;
@@ -35,16 +48,20 @@ export function ensureProfileDir(): string {
   return dir;
 }
 
-export async function readProfileFile(name: ProfileFile): Promise<string> {
-  return (await (await getStore()).docs.readDoc(NS, `${name}.md`)) ?? "";
+export async function readProfileFile(name: ProfileFile, scope: string = scopeDefault()): Promise<string> {
+  return (await (await getStore()).docs.readDoc(NS, docId(scope, `${name}.md`))) ?? "";
 }
 
-export async function writeProfileFile(name: ProfileFile, content: string): Promise<void> {
-  await (await getStore()).docs.writeDoc(NS, `${name}.md`, content);
+export async function writeProfileFile(
+  name: ProfileFile,
+  content: string,
+  scope: string = scopeDefault(),
+): Promise<void> {
+  await (await getStore()).docs.writeDoc(NS, docId(scope, `${name}.md`), content);
 }
 
-export async function readRoles(): Promise<Roles> {
-  const raw = await (await getStore()).docs.readDoc(NS, "roles.json");
+export async function readRoles(scope: string = scopeDefault()): Promise<Roles> {
+  const raw = await (await getStore()).docs.readDoc(NS, docId(scope, "roles.json"));
   if (!raw) return { ...EMPTY_ROLES };
   try {
     const parsed = JSON.parse(raw) as Partial<Roles>;
@@ -58,8 +75,8 @@ export async function readRoles(): Promise<Roles> {
   }
 }
 
-export async function writeRoles(roles: Roles): Promise<void> {
-  await (await getStore()).docs.writeDoc(NS, "roles.json", JSON.stringify(roles, null, 2));
+export async function writeRoles(roles: Roles, scope: string = scopeDefault()): Promise<void> {
+  await (await getStore()).docs.writeDoc(NS, docId(scope, "roles.json"), JSON.stringify(roles, null, 2));
 }
 
 export function activeRoles(roles: Roles): string[] {
@@ -76,10 +93,10 @@ export function rawResumePath(): string {
   return join(profileDir(), "raw-resume.txt");
 }
 
-export async function writeRawResume(text: string): Promise<void> {
-  await (await getStore()).docs.writeDoc(NS, "raw-resume.txt", text);
+export async function writeRawResume(text: string, scope: string = scopeDefault()): Promise<void> {
+  await (await getStore()).docs.writeDoc(NS, docId(scope, "raw-resume.txt"), text);
 }
 
-export async function readRawResume(): Promise<string> {
-  return (await (await getStore()).docs.readDoc(NS, "raw-resume.txt")) ?? "";
+export async function readRawResume(scope: string = scopeDefault()): Promise<string> {
+  return (await (await getStore()).docs.readDoc(NS, docId(scope, "raw-resume.txt"))) ?? "";
 }

--- a/mcp-server/src/lib/run-context.ts
+++ b/mcp-server/src/lib/run-context.ts
@@ -1,0 +1,24 @@
+// Per-run scope propagation. When the server runs an agent on behalf of a user,
+// it sets the user's uid in this AsyncLocalStorage for the duration of the run.
+// The per-user stores (pipeline, profile) read `currentScope()` so the existing
+// tool handlers — which take no uid argument — automatically read/write the right
+// user's data. Outside a run (MCP/stdio single-user path) there's no store set, so
+// `currentScope()` returns undefined and callers fall back to "default".
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+interface RunScope {
+  uid: string;
+}
+
+const storage = new AsyncLocalStorage<RunScope>();
+
+/** Run `fn` with `uid` as the ambient scope (propagates through awaits). */
+export function runWithScope<T>(uid: string, fn: () => Promise<T>): Promise<T> {
+  return storage.run({ uid }, fn);
+}
+
+/** The current run's uid, or undefined when not inside a scoped run. */
+export function currentScope(): string | undefined {
+  return storage.getStore()?.uid;
+}

--- a/mcp-server/tsup.config.ts
+++ b/mcp-server/tsup.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   splitting: false,
   shims: true,
   platform: "node",
-  external: ["node:sqlite", "@huggingface/transformers", "onnxruntime-node", "firebase-admin"],
+  external: ["node:sqlite", "@huggingface/transformers", "onnxruntime-node", "firebase-admin", "@anthropic-ai/sdk"],
   define: {
     __JOBSYNC_VERSION__: JSON.stringify(pkg.version),
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
 
   mcp-server:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.71.0
+        version: 0.71.2(zod@3.25.76)
       '@google-cloud/firestore':
         specifier: ^7.10.0
         version: 7.11.6
@@ -161,6 +164,15 @@ packages:
 
   '@anthropic-ai/sdk@0.39.0':
     resolution: {integrity: sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==}
+
+  '@anthropic-ai/sdk@0.71.2':
+    resolution: {integrity: sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -232,6 +244,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
@@ -2252,6 +2268,10 @@ packages:
   json-schema-ref-resolver@3.0.0:
     resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -2967,6 +2987,9 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -3261,6 +3284,12 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@anthropic-ai/sdk@0.71.2(zod@3.25.76)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 3.25.76
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -3349,6 +3378,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -5422,6 +5453,11 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
+
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
@@ -6178,6 +6214,8 @@ snapshots:
   tr46@0.0.3: {}
 
   tree-kill@1.2.2: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-interface-checker@0.1.13: {}
 


### PR DESCRIPTION
- Implemented Anthropic client in `anthropic.ts` for server-side agent runtime.
- Created `search-agent.ts` to manage job search functionality using Anthropic's web search.
- Developed tools bridge in `tools-bridge.ts` to connect jobsync tools with Anthropic.
- Added tests for tools bridge in `tools-bridge.test.ts`.
- Enhanced personal profile management in `personal-profile.ts` to support multi-user scope.
- Updated pipeline management in `pipeline.ts` to utilize user-specific scopes.
- Introduced `profile-extract.ts` for structuring resumes into job profiles using Anthropic.
- Added tests for profile management in `profile.test.ts`.
- Refactored profile reading and writing functions to support scoped access.
- Updated dependencies in `pnpm-lock.yaml` to include `@anthropic-ai/sdk`.

## What does this PR do?

<!-- One paragraph. Link the issue it closes if there is one. -->

Closes #

## How was it verified?

<!-- Describe what you ran or tested. -->

- [ ] `pnpm --filter jobsync-mcp typecheck` passes
- [ ] `pnpm --filter jobsync-mcp build` passes
- [ ] `pnpm --filter jobsync-mcp test` passes
- [ ] Tested manually against Claude Code / Claude Desktop (for tool changes)

## Checklist

- [ ] Scoped to one problem or feature
- [ ] No secrets, Airtable tokens, resumes, or personal data included
- [ ] Docs updated if CLI commands, MCP tool names, or config keys changed
- [ ] New or updated tests included for logic changes
