### PR TITLE
Agent evals

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -112,10 +112,23 @@
       "Bash(curl -s \"https://api.ashbyhq.com/posting-api/job-board/linear?includeCompensation=true\")",
       "Bash(curl -s \"https://api.ashbyhq.com/posting-api/job-board/ramp?includeCompensation=true\")",
       "Bash(pnpm add *)",
-      "Bash(pnpm exec *)"
+      "Bash(pnpm exec *)",
+      "WebFetch(domain:www.anthropic.com)",
+      "PowerShell(gh auth status)",
+      "PowerShell(npx tsc --noEmit 2>&1)",
+      "PowerShell($pwd.Path; if \\(Test-Path src/tools/link-check-tools.test.ts\\) { npx vitest run src/tools/link-check-tools.test.ts 2>&1 | Select-Object -Last 15 } else { \"no link-check test file\" })",
+      "PowerShell(npx vitest run src/lib/agent/ 2>&1)",
+      "PowerShell(\"---TESTS---\")",
+      "Bash(printf -- '- [AI-call config file]\\(ai_config_file.md\\) — all 4 Anthropic call sites tuned via mcp-server/ai.config.json; env JOBSYNC_AGENT_MODEL still wins\\\\n' >> \"/c/Users/vyasm/.claude/projects/c--Users-vyasm-OneDrive-Desktop-JobsList/memory/MEMORY.md\")",
+      "PowerShell(npx vitest run src/lib/agent/ src/lib/pipeline.test.ts 2>&1)",
+      "PowerShell(npx tsc -p mcp-server/tsconfig.json --noEmit 2>&1 | Select-String -Pattern \"error TS\" | Select-Object -First 30; \"EXIT:$LASTEXITCODE\")",
+      "PowerShell(npx vitest run mcp-server/src/lib/agent/search-agent.test.ts mcp-server/src/lib/pipeline.test.ts mcp-server/src/lib/agent/search-audit.test.ts 2>&1)",
+      "PowerShell(npx vitest run mcp-server/src/lib/eval/ 2>&1)",
+      "PowerShell(npx vitest run mcp-server/src/lib/agent/ mcp-server/src/lib/pipeline.test.ts mcp-server/src/lib/eval/ 2>&1)"
     ],
     "additionalDirectories": [
-      "c:\\Users\\vyasm\\.claude\\projects\\c--Users-vyasm-OneDrive-Desktop-JobsList\\memory"
+      "c:\\Users\\vyasm\\.claude\\projects\\c--Users-vyasm-OneDrive-Desktop-JobsList\\memory",
+      "C:\\Users\\vyasm\\.claude\\projects\\c--Users-vyasm-OneDrive-Desktop-JobsList\\memory"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -124,7 +124,11 @@
       "PowerShell(npx tsc -p mcp-server/tsconfig.json --noEmit 2>&1 | Select-String -Pattern \"error TS\" | Select-Object -First 30; \"EXIT:$LASTEXITCODE\")",
       "PowerShell(npx vitest run mcp-server/src/lib/agent/search-agent.test.ts mcp-server/src/lib/pipeline.test.ts mcp-server/src/lib/agent/search-audit.test.ts 2>&1)",
       "PowerShell(npx vitest run mcp-server/src/lib/eval/ 2>&1)",
-      "PowerShell(npx vitest run mcp-server/src/lib/agent/ mcp-server/src/lib/pipeline.test.ts mcp-server/src/lib/eval/ 2>&1)"
+      "PowerShell(npx vitest run mcp-server/src/lib/agent/ mcp-server/src/lib/pipeline.test.ts mcp-server/src/lib/eval/ 2>&1)",
+      "PowerShell(\"---status---\")",
+      "PowerShell(\"---log vs main---\")",
+      "PowerShell(npx vitest run --root mcp-server 2>&1)",
+      "PowerShell(pnpm --filter jobsync-mcp build 2>&1 | Select-Object -Last 15; \"BUILD_EXIT:$LASTEXITCODE\")"
     ],
     "additionalDirectories": [
       "c:\\Users\\vyasm\\.claude\\projects\\c--Users-vyasm-OneDrive-Desktop-JobsList\\memory",

--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,17 @@ FIREBASE_API_KEY=
 ANTHROPIC_API_KEY=sk-ant-...
 JOBSYNC_AGENT_MODEL=claude-sonnet-4-6
 
+# Optional: route the lightweight Auto-Apply / resume-structuring LLM calls to a
+# cheaper or FREE OpenAI-compatible provider (for testing — saves Anthropic tokens).
+# The Search agent always stays on Anthropic. Set the model via JOBSYNC_AGENT_MODEL
+# (or ai.config.json) to one the provider understands, e.g. "gemini-2.0-flash".
+#   Gemini (free tier):  https://generativelanguage.googleapis.com/v1beta/openai/
+#   Groq (free tier):    https://api.groq.com/openai/v1
+#   OpenRouter:          https://openrouter.ai/api/v1
+# JOBSYNC_LLM_PROVIDER=openai
+# JOBSYNC_LLM_API_KEY=
+# JOBSYNC_LLM_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai/
+
 # Server
 PORT=3001
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,9 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /app/mcp-server/dist ./mcp-server/dist
+# Tweakable AI-call config (models/tokens/loop budgets) — ai-config.ts finds it
+# by walking up from dist/ at runtime.
+COPY --from=build /app/mcp-server/ai.config.json ./mcp-server/ai.config.json
 # Dashboard static build served by http.js (PUBLIC_DIR = ./public next to the bundle).
 COPY --from=build /app/dashboard/dist ./mcp-server/dist/public
 

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -69,6 +69,16 @@ export interface ProposedField {
   editable: boolean;
 }
 
+/** A required question the agent couldn't answer from the profile — the console
+ *  asks the user, and the answer is saved to per-user Q&A memory. */
+export interface NeededInput {
+  selector: string;
+  label: string;
+  type: string;
+  required: boolean;
+  options: string[];
+}
+
 export interface RunMeta {
   location?: string;
   datePosted?: string;
@@ -92,6 +102,7 @@ export interface Run {
   // Auto-Apply
   previews?: PreviewFrame[];
   proposed?: { filled: ProposedField[]; unfilledRequired: string[] };
+  needsInput?: NeededInput[];
   applyLink?: string;
   jobId?: string;
   company?: string;
@@ -148,6 +159,18 @@ export interface Personal {
   linkedinUrl?: string;
   githubUrl?: string;
   portfolioUrl?: string;
+  twitterUrl?: string;
+  scholarUrl?: string;
+  otherUrls?: string;
+  // Work authorization
+  workAuthorization?: string;
+  requiresSponsorship?: boolean;
+  // Voluntary EEO self-identification (all optional)
+  gender?: string;
+  pronouns?: string;
+  ethnicity?: string;
+  veteranStatus?: string;
+  disabilityStatus?: string;
 }
 
 export interface Profile {

--- a/dashboard/src/components/Agents.tsx
+++ b/dashboard/src/components/Agents.tsx
@@ -6,6 +6,7 @@ import {
   previewSrc,
   TWEAKS,
   type Agent,
+  type NeededInput,
   type ProposedField,
   type Run,
 } from "../api";
@@ -22,7 +23,7 @@ function agentLabel(id: string): string {
 // Statuses where the run is finished and polling should stop.
 const TERMINAL = new Set(["succeeded", "failed", "cancelled"]);
 // While in one of these the apply browser is open, so the live pane should refresh.
-const LIVE = new Set(["running", "queued", "awaiting_approval", "awaiting_code"]);
+const LIVE = new Set(["running", "queued", "awaiting_approval", "awaiting_input", "awaiting_code"]);
 
 export default function Agents() {
   const [agents, setAgents] = useState<Agent[]>([]);
@@ -57,8 +58,13 @@ export default function Agents() {
       try {
         const run = await apiFetch<Run>(`/api/runs/${encodeURIComponent(id)}`);
         setActive((cur) => (cur && cur.id === id ? run : cur));
-        // Stop on terminal OR awaiting_approval (now it's the user's move).
-        if (TERMINAL.has(run.status) || run.status === "awaiting_approval") {
+        // Stop when it's the user's move (approve / answer questions / enter code) or terminal.
+        if (
+          TERMINAL.has(run.status) ||
+          run.status === "awaiting_approval" ||
+          run.status === "awaiting_input" ||
+          run.status === "awaiting_code"
+        ) {
           stopPolling();
           await refresh();
         }
@@ -147,6 +153,26 @@ export default function Agents() {
     }
   }
 
+  // Supply answers to questions the agent couldn't fill — saved to Q&A memory, then
+  // the application is re-prepared with them.
+  async function submitAnswers(id: string, answers: Array<{ label: string; value: string }>) {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await apiFetch<{ run: Run }>(`/api/runs/${encodeURIComponent(id)}/answers`, {
+        method: "POST",
+        body: JSON.stringify({ answers }),
+      });
+      setActive(res.run);
+      if (res.run.status === "running") pollRun(res.run.id);
+      else await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
   // Enter the emailed verification code on a run paused at the code gate.
   async function submitCode(id: string, code: string) {
     setBusy(true);
@@ -183,6 +209,7 @@ export default function Agents() {
           onDecide={decide}
           onRevise={reviseField}
           onSubmitCode={submitCode}
+          onSubmitAnswers={submitAnswers}
           onClose={() => {
             stopPolling();
             setActive(null);
@@ -250,6 +277,7 @@ function Console({
   onDecide,
   onRevise,
   onSubmitCode,
+  onSubmitAnswers,
   onClose,
 }: {
   run: Run;
@@ -257,6 +285,7 @@ function Console({
   onDecide: (id: string, action: "approve" | "discard" | "accept-all") => void;
   onRevise: (id: string, body: Record<string, unknown>, kind: "tweak" | "edit") => Promise<void>;
   onSubmitCode: (id: string, code: string) => void;
+  onSubmitAnswers: (id: string, answers: Array<{ label: string; value: string }>) => void;
   onClose: () => void;
 }) {
   const live = LIVE.has(run.status);
@@ -287,6 +316,7 @@ function Console({
             onDecide={onDecide}
             onRevise={onRevise}
             onSubmitCode={onSubmitCode}
+            onSubmitAnswers={onSubmitAnswers}
           />
         </div>
         <LiveBrowser run={run} />
@@ -335,12 +365,14 @@ function LogAndApprove({
   onDecide,
   onRevise,
   onSubmitCode,
+  onSubmitAnswers,
 }: {
   run: Run;
   busy: boolean;
   onDecide: (id: string, action: "approve" | "discard" | "accept-all") => void;
   onRevise: (id: string, body: Record<string, unknown>, kind: "tweak" | "edit") => Promise<void>;
   onSubmitCode: (id: string, code: string) => void;
+  onSubmitAnswers: (id: string, answers: Array<{ label: string; value: string }>) => void;
 }) {
   const bodyRef = useRef<HTMLDivElement | null>(null);
   const [code, setCode] = useState("");
@@ -368,6 +400,14 @@ function LogAndApprove({
             </a>
           )}
         </div>
+      )}
+
+      {run.status === "awaiting_input" && run.needsInput && run.needsInput.length > 0 && (
+        <NeedsInputBox
+          questions={run.needsInput}
+          busy={busy}
+          onSubmit={(answers) => onSubmitAnswers(run.id, answers)}
+        />
       )}
 
       {run.status === "awaiting_code" && (
@@ -529,6 +569,72 @@ function AnswerRow({
           )}
         </>
       )}
+    </div>
+  );
+}
+
+function NeedsInputBox({
+  questions,
+  busy,
+  onSubmit,
+}: {
+  questions: NeededInput[];
+  busy: boolean;
+  onSubmit: (answers: Array<{ label: string; value: string }>) => void;
+}) {
+  const [values, setValues] = useState<Record<string, string>>({});
+
+  const set = (selector: string, v: string) => setValues((prev) => ({ ...prev, [selector]: v }));
+  const answers = questions
+    .map((q) => ({ label: q.label, value: (values[q.selector] ?? "").trim() }))
+    .filter((a) => a.value);
+  const allRequiredAnswered = questions
+    .filter((q) => q.required)
+    .every((q) => (values[q.selector] ?? "").trim());
+
+  return (
+    <div className="approve-box needs-input-box">
+      <strong className="small">The agent needs a few answers</strong>
+      <p className="muted small">
+        These required questions aren't in your profile. Answer them once — they're saved to your
+        profile memory and reused automatically next time.
+      </p>
+      <div className="answers">
+        {questions.map((q) => (
+          <div className="answer-row" key={q.selector}>
+            <div className="answer-label small">
+              <span className="muted">{q.label}</span>
+              {q.required && <span className="req">required</span>}
+            </div>
+            {q.options.length > 0 ? (
+              <select value={values[q.selector] ?? ""} onChange={(e) => set(q.selector, e.target.value)}>
+                <option value="">Select…</option>
+                {q.options.map((o) => (
+                  <option key={o} value={o}>
+                    {o}
+                  </option>
+                ))}
+              </select>
+            ) : q.type === "textarea" ? (
+              <textarea
+                rows={3}
+                value={values[q.selector] ?? ""}
+                onChange={(e) => set(q.selector, e.target.value)}
+              />
+            ) : (
+              <input
+                value={values[q.selector] ?? ""}
+                onChange={(e) => set(q.selector, e.target.value)}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+      <div className="approve-actions">
+        <button onClick={() => onSubmit(answers)} disabled={busy || !allRequiredAnswered}>
+          {busy ? "Saving…" : "Save answers & continue"}
+        </button>
+      </div>
     </div>
   );
 }

--- a/dashboard/src/components/Profile.tsx
+++ b/dashboard/src/components/Profile.tsx
@@ -69,7 +69,7 @@ export default function Profile() {
     <label>
       {label}
       <input
-        value={personal[key] ?? ""}
+        value={(personal[key] as string) ?? ""}
         onChange={(e) => setPersonal({ ...personal, [key]: e.target.value })}
       />
     </label>

--- a/dashboard/src/pages/Dashboard.tsx
+++ b/dashboard/src/pages/Dashboard.tsx
@@ -1,21 +1,36 @@
 import { useEffect, useState } from "react";
-import { NavLink, Navigate, Route, Routes } from "react-router-dom";
+import { NavLink, Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "../auth";
-import { apiFetch } from "../api";
+import { apiFetch, type Profile as ProfileT } from "../api";
 import Agents from "../components/Agents";
 import Pipeline from "../components/Pipeline";
 import Profile from "../components/Profile";
+import Onboarding from "./Onboarding";
 
 export default function Dashboard() {
   const { user, logout } = useAuth();
   const [ready, setReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+  const location = useLocation();
 
-  // Register/refresh the user record on the server (creates users/<uid>).
+  // Register/refresh the user record on the server (creates users/<uid>), then send
+  // brand-new users (no resume + no name yet) into the onboarding flow once.
   useEffect(() => {
+    let cancelled = false;
     apiFetch("/api/me")
-      .then(() => setReady(true))
+      .then(() => apiFetch<ProfileT>("/api/profile"))
+      .then((p) => {
+        if (cancelled) return;
+        setReady(true);
+        const incomplete = !p.hasResume && !p.personal?.firstName;
+        if (incomplete && location.pathname === "/") navigate("/onboarding", { replace: true });
+      })
       .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)));
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
@@ -26,6 +41,7 @@ export default function Dashboard() {
           <NavLink to="/agents">Agents</NavLink>
           <NavLink to="/pipeline">Pipeline</NavLink>
           <NavLink to="/profile">Profile</NavLink>
+          <NavLink to="/onboarding">Set up profile</NavLink>
         </nav>
         <div className="sidebar-footer">
           <div className="muted email">{user?.email}</div>
@@ -44,6 +60,7 @@ export default function Dashboard() {
             <Route path="/agents" element={<Agents />} />
             <Route path="/pipeline" element={<Pipeline />} />
             <Route path="/profile" element={<Profile />} />
+            <Route path="/onboarding" element={<Onboarding />} />
             <Route path="*" element={<Navigate to="/agents" replace />} />
           </Routes>
         )}

--- a/dashboard/src/pages/Onboarding.tsx
+++ b/dashboard/src/pages/Onboarding.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useMemo, useState, type ChangeEvent, type ReactNode } from "react";
+import { useNavigate } from "react-router-dom";
+import { apiFetch, fileToBase64, type Personal, type Profile as ProfileT } from "../api";
+
+// Typeform-style, one-step-at-a-time onboarding. Collects everything Auto-Apply
+// needs that the resume alone can't supply: contact, work authorization, social
+// links, and (voluntary) EEO self-identification. Saves through the existing
+// /api/profile + /api/profile/resume endpoints — no new server routes.
+
+const GENDER_OPTIONS = ["Male", "Female", "Non-binary", "Decline to self-identify"];
+const ETHNICITY_OPTIONS = [
+  "Asian",
+  "White",
+  "Black or African American",
+  "Hispanic or Latino",
+  "Native American or Alaska Native",
+  "Native Hawaiian or Pacific Islander",
+  "Two or More Races",
+  "Decline to self-identify",
+];
+const YESNO_DECLINE = ["Yes", "No", "Decline to self-identify"];
+const WORK_AUTH_OPTIONS = [
+  "US Citizen",
+  "Green Card",
+  "H1B Visa",
+  "OPT",
+  "CPT",
+  "TN Visa",
+  "Other",
+];
+
+export default function Onboarding() {
+  const navigate = useNavigate();
+  const [personal, setPersonal] = useState<Personal>({});
+  const [hasResume, setHasResume] = useState(false);
+  const [step, setStep] = useState(0);
+  const [uploading, setUploading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  useEffect(() => {
+    apiFetch<ProfileT>("/api/profile")
+      .then((p) => {
+        setPersonal(p.personal ?? {});
+        setHasResume(p.hasResume);
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : String(e)));
+  }, []);
+
+  const set = (key: keyof Personal, value: string | boolean) =>
+    setPersonal((prev) => ({ ...prev, [key]: value }));
+
+  async function onResume(e: ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const base64 = await fileToBase64(file);
+      const p = await apiFetch<ProfileT>("/api/profile/resume", {
+        method: "POST",
+        body: JSON.stringify({ filename: file.name, base64 }),
+      });
+      setPersonal((prev) => ({ ...(p.personal ?? {}), ...prev }));
+      setHasResume(true);
+      setNotice("Resume uploaded and parsed — it'll be attached to your applications.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setUploading(false);
+      e.target.value = "";
+    }
+  }
+
+  const text = (key: keyof Personal, label: string, placeholder = "") => (
+    <label className="ob-field" key={key}>
+      <span>{label}</span>
+      <input
+        value={(personal[key] as string) ?? ""}
+        placeholder={placeholder}
+        onChange={(e) => set(key, e.target.value)}
+      />
+    </label>
+  );
+
+  const select = (key: keyof Personal, label: string, options: string[]) => (
+    <label className="ob-field" key={key}>
+      <span>{label}</span>
+      <select value={(personal[key] as string) ?? ""} onChange={(e) => set(key, e.target.value)}>
+        <option value="">Select…</option>
+        {options.map((o) => (
+          <option key={o} value={o}>
+            {o}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+
+  const steps: Array<{ title: string; subtitle: string; body: ReactNode }> = useMemo(
+    () => [
+      {
+        title: "Upload your resume",
+        subtitle:
+          "We parse it into target roles + skills, and attach the original file to your applications.",
+        body: (
+          <div className="ob-resume">
+            <p className="muted">{hasResume ? "✓ A resume is on file." : "No resume uploaded yet."}</p>
+            <label className="file-btn">
+              {uploading ? "Parsing…" : hasResume ? "Replace resume" : "Upload resume (PDF / DOCX / TXT)"}
+              <input
+                type="file"
+                accept=".pdf,.docx,.txt,.md"
+                onChange={onResume}
+                disabled={uploading}
+                hidden
+              />
+            </label>
+          </div>
+        ),
+      },
+      {
+        title: "About you",
+        subtitle: "The basics every application asks for.",
+        body: (
+          <div className="ob-grid">
+            {text("firstName", "First name")}
+            {text("lastName", "Last name")}
+            {text("email", "Email")}
+            {text("phone", "Phone")}
+          </div>
+        ),
+      },
+      {
+        title: "Location & work authorization",
+        subtitle: "Used for location fields and the standard eligibility questions.",
+        body: (
+          <div className="ob-grid">
+            {text("city", "City")}
+            {text("state", "State / Province")}
+            {text("country", "Country", "United States")}
+            {select("workAuthorization", "Work authorization", WORK_AUTH_OPTIONS)}
+            <label className="ob-field ob-check">
+              <input
+                type="checkbox"
+                checked={Boolean(personal.requiresSponsorship)}
+                onChange={(e) => set("requiresSponsorship", e.target.checked)}
+              />
+              <span>I will require visa sponsorship now or in the future</span>
+            </label>
+          </div>
+        ),
+      },
+      {
+        title: "Your links",
+        subtitle: "Profiles recruiters and forms ask for. Leave any blank.",
+        body: (
+          <div className="ob-grid">
+            {text("linkedinUrl", "LinkedIn", "https://linkedin.com/in/…")}
+            {text("githubUrl", "GitHub", "https://github.com/…")}
+            {text("twitterUrl", "X (Twitter)", "https://x.com/…")}
+            {text("scholarUrl", "Google Scholar", "https://scholar.google.com/…")}
+            {text("portfolioUrl", "Portfolio / website")}
+            {text("otherUrls", "Other links", "comma-separated")}
+          </div>
+        ),
+      },
+      {
+        title: "Voluntary self-identification",
+        subtitle:
+          "Entirely optional. US applications ask these for EEO reporting — pre-filling them saves time. You can decline any.",
+        body: (
+          <div className="ob-grid">
+            {select("gender", "Gender", GENDER_OPTIONS)}
+            {text("pronouns", "Pronouns", "e.g. she/her")}
+            {select("ethnicity", "Race / Ethnicity", ETHNICITY_OPTIONS)}
+            {select("veteranStatus", "Protected veteran status", YESNO_DECLINE)}
+            {select("disabilityStatus", "Disability status", YESNO_DECLINE)}
+          </div>
+        ),
+      },
+    ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [personal, hasResume, uploading],
+  );
+
+  const last = step === steps.length - 1;
+
+  async function finish() {
+    setSaving(true);
+    setError(null);
+    try {
+      await apiFetch("/api/profile", { method: "PUT", body: JSON.stringify({ personal }) });
+      navigate("/agents");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function next() {
+    if (last) return finish();
+    // Persist progress as we go so a refresh doesn't lose it.
+    setPersonal((p) => p);
+    apiFetch("/api/profile", { method: "PUT", body: JSON.stringify({ personal }) }).catch(() => {});
+    setStep((s) => Math.min(s + 1, steps.length - 1));
+    setNotice(null);
+  }
+
+  const current = steps[step];
+
+  return (
+    <div className="onboarding">
+      <div className="ob-card">
+        <div className="ob-progress">
+          {steps.map((_, i) => (
+            <span key={i} className={`ob-dot ${i <= step ? "on" : ""}`} />
+          ))}
+        </div>
+        <div className="ob-step-count muted small">
+          Step {step + 1} of {steps.length}
+        </div>
+
+        <h1>{current.title}</h1>
+        <p className="muted">{current.subtitle}</p>
+
+        {notice && <p className="notice">{notice}</p>}
+        {error && <p className="error">{error}</p>}
+
+        <div className="ob-body">{current.body}</div>
+
+        <div className="ob-actions">
+          {step > 0 ? (
+            <button className="ghost" onClick={() => setStep((s) => Math.max(0, s - 1))}>
+              ← Back
+            </button>
+          ) : (
+            <button className="link" onClick={() => navigate("/agents")}>
+              Skip for now
+            </button>
+          )}
+          <button onClick={next} disabled={saving || uploading}>
+            {last ? (saving ? "Saving…" : "Finish") : "Next →"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -336,3 +336,51 @@ button.ghost { background: var(--panel-2); color: var(--text); border: 1px solid
 .autonomous-toggle { display: flex; align-items: center; gap: 6px; cursor: pointer; }
 .autonomous-toggle input { margin: 0; }
 .lever-note { margin-top: 8px; }
+
+/* ── Onboarding (typeform-style) ─────────────────────────────────────────────── */
+.onboarding {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 24px 12px;
+}
+.ob-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 28px 32px;
+  width: 100%;
+  max-width: 640px;
+}
+.ob-progress { display: flex; gap: 6px; margin-bottom: 6px; }
+.ob-dot { flex: 1; height: 4px; border-radius: 4px; background: var(--panel-2); }
+.ob-dot.on { background: var(--accent); }
+.ob-step-count { margin-bottom: 12px; }
+.ob-card h1 { margin: 0 0 6px; font-size: 24px; }
+.ob-body { margin: 20px 0 24px; }
+.ob-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+.ob-field { display: flex; flex-direction: column; gap: 4px; font-size: 13px; color: var(--muted); }
+.ob-field input, .ob-field select {
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 9px 10px;
+  color: var(--text);
+  font-size: 14px;
+}
+.ob-check { flex-direction: row; align-items: center; gap: 8px; grid-column: 1 / -1; color: var(--text); }
+.ob-check input { width: auto; }
+.ob-resume { display: flex; flex-direction: column; gap: 10px; align-items: flex-start; }
+.ob-actions { display: flex; justify-content: space-between; align-items: center; }
+@media (max-width: 560px) { .ob-grid { grid-template-columns: 1fr; } }
+
+/* ── Auto-Apply: agent needs answers ─────────────────────────────────────────── */
+.needs-input-box select, .needs-input-box input, .needs-input-box textarea {
+  width: 100%;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 10px;
+  color: var(--text);
+  font-size: 13px;
+}

--- a/docs/agent-architecture-and-evals.md
+++ b/docs/agent-architecture-and-evals.md
@@ -1,0 +1,504 @@
+# JobSync MCP — Agent Architecture, Evals & Verifiers
+
+> Source of truth: `mcp-server/src/lib/agent/` (search-agent.ts, auto-apply-agent.ts,
+> tools-bridge.ts, anthropic.ts, ai-config.ts) and `mcp-server/src/api/dashboard.ts`.
+> All AI-call tuning (models, token budgets, temperature, search-loop budgets) lives in
+> **`mcp-server/ai.config.json`**; `JOBSYNC_AGENT_MODEL` remains the deploy/eval-matrix
+> model override that beats the file.
+> Eval design follows Anthropic's
+> [Demystifying evals for AI agents](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents).
+
+---
+
+## 1. System overview
+
+```mermaid
+flowchart LR
+  subgraph Client
+    UI[React Dashboard<br/>Firebase Auth]
+  end
+  subgraph Server["mcp-server (Cloud Run)"]
+    API[dashboard.ts API<br/>run records + progress log]
+    SA[Search Agent<br/>autonomous tool-use loop]
+    AA[Auto-Apply Agent<br/>orchestrated pipeline + HITL gate]
+    BRIDGE[tools-bridge<br/>MCP registry → Anthropic tools]
+    TOOLS[(jobsync MCP tools)]
+    BROWSER[browser-apply.ts<br/>patchright session singleton]
+  end
+  subgraph External
+    ANTH[Anthropic API<br/>JOBSYNC_AGENT_MODEL<br/>default claude-sonnet-4-6]
+    WS[web_search server tool]
+    ATS[Greenhouse / Lever / Ashby / Workday]
+    ES[(Elasticsearch jobs_v2<br/>mutu.dev)]
+    PIPE[(Per-user pipeline)]
+    IMAP[IMAP email-code fetch]
+  end
+
+  UI -->|POST /agent/search| API --> SA
+  UI -->|prepare / approve / tweak / code / discard| API --> AA
+  SA <-->|messages loop| ANTH
+  ANTH <--> WS
+  SA --> BRIDGE --> TOOLS
+  TOOLS --> ATS & ES & PIPE
+  AA -->|composeAnswers, tweakAnswer<br/>single LLM calls| ANTH
+  AA --> BROWSER --> ATS
+  AA --> PIPE
+  BROWSER -.email code gate.-> IMAP
+```
+
+Two very different designs share one runtime:
+
+| | Search Agent | Auto-Apply Agent |
+|---|---|---|
+| Control flow | **Model-driven** (Claude decides which tools, in what order, when to stop) | **Code-driven** (fixed TypeScript pipeline; Claude only writes answer text) |
+| Loop | `while (iterations < 40)` Messages-API tool-use loop | No loop — `prepare → approve → submit` state machine |
+| LLM calls | One conversation, many turns | 2 isolated calls: `composeAnswers` (structured output), `tweakAnswer` |
+| Human in the loop | None (fire-and-forget, progress log) | Mandatory approval gate + tweak/edit before submit |
+| Side-effect risk | Writes to pipeline/cache/ES | Submits real applications → gated |
+| Concurrency | Per-user (`runWithScope(uid)`) | Process-wide singleton — one application at a time |
+
+---
+
+## 2. Search Agent workflow
+
+### 2.1 Runtime loop (how it actually executes)
+
+```mermaid
+flowchart TB
+  START[POST /agent/search<br/>uid, lookbackHours=48, roles, companies] --> KICK[Build kickoff message]
+  KICK --> CALL[client.messages.create<br/>system prompt + 20 bridged tools + web_search<br/>container id threaded for web_search]
+  CALL --> SR{stop_reason}
+  SR -->|tool_use| EXEC[runBridgedTool for each tool_use<br/>result truncated to 60k chars<br/>tally added/updated from pipeline_upsert_jobs]
+  EXEC --> CALL
+  SR -->|pause_turn<br/>web_search internal limit| CALL
+  SR -->|end_turn| DONE[Return SearchResult<br/>added, updated, iterations, summary]
+  SR -->|refusal / max_tokens / other| DONE
+  CALL -->|iteration 40 hit| DONE
+```
+
+### 2.2 Prescribed pipeline (what the system prompt tells the model to do)
+
+```mermaid
+flowchart LR
+  P1[1. Load profile<br/>profile_read] --> P2[2. Boards<br/>portals_read]
+  P2 --> P3[3. Discover<br/>fetch_greenhouse_jobs<br/>fetch_lever_jobs<br/>fetch_ashby_jobs<br/>fetch_workday_jobs<br/>web_search]
+  P3 --> P4[4. Enrich + filter<br/>scrape_job_details<br/>ashby_get_date_posted_batch<br/>filter_us_location<br/>filter_title_keywords<br/>classify_job_batch<br/>detect_industry_tags]
+  P4 --> P5[5. Verify links<br/>verify_job_link_batch]
+  P5 --> P6[6. Dedupe<br/>cache_is_seen<br/>elasticsearch_list_recent_jobs]
+  P6 --> P7[7. Land<br/>pipeline_upsert_jobs<br/>cache_mark_seen<br/>elasticsearch_index_jobs]
+  P7 --> P8[8. Summarize<br/>one paragraph]
+```
+
+**Important nuance:** the numbered pipeline lives in the *prompt*, not the code. The model
+is free to reorder, skip, or batch steps — that's what makes it agentic, and also what
+makes it need verifiers (nothing in code enforces that step 5 happened before step 7).
+
+### 2.3 Search Agent skill set (`SEARCH_AGENT_TOOLS` allowlist)
+
+| Category | Tools |
+|---|---|
+| Identity / context | `profile_read`, `portals_read`, `jobsync_ping` |
+| Discovery | `fetch_greenhouse_jobs`, `fetch_lever_jobs`, `fetch_ashby_jobs`, `fetch_workday_jobs`, **`web_search`** (Anthropic server tool) |
+| Enrichment | `scrape_job_details`, `ashby_get_date_posted_batch` |
+| Filtering / scoring | `filter_us_location`, `filter_title_keywords`, `classify_job_batch`, `detect_industry_tags` |
+| Verification | `verify_job_link`, `verify_job_link_batch` |
+| Dedupe / memory | `cache_is_seen`, `cache_mark_seen`, `elasticsearch_list_recent_jobs` |
+| Persistence | `pipeline_upsert_jobs`, `elasticsearch_index_jobs` |
+
+Deliberately excluded: all browser/apply tools, Airtable writes, profile writes —
+the allowlist is the agent's blast-radius boundary.
+
+---
+
+## 3. Auto-Apply Agent workflow
+
+```mermaid
+stateDiagram-v2
+  [*] --> Preparing: prepareApplication(uid, applyLink)
+  state Preparing {
+    [*] --> Inspect: inspectForm() → patchright opens form,<br/>screenshot, atsHint, field list
+    Inspect --> MapProfile: fillFields() — deterministic mapping<br/>from personal profile + experience/skills/projects
+    MapProfile --> Compose: composeAnswers() — ONE Claude call,<br/>JSON-schema output, answers remaining fields
+    Compose --> Draft: saveApplyDraft()
+    Draft --> DryRun: fillAndSubmit(dryRun=true)<br/>screenshot preview, nothing submitted
+  }
+  Preparing --> AwaitingApproval: PreparedApplication<br/>(filled fields, unfilledRequired, editable flags)
+
+  state AwaitingApproval {
+    [*] --> Review
+    Review --> Review: tweakAnswer() — formal/shorten/humanize/<br/>informal/more-facts/freeform (LLM call, patches draft)
+    Review --> Review: editAnswer() — manual overwrite (no LLM)
+  }
+
+  AwaitingApproval --> Submitting: user approves →<br/>submitPreparedApplication()
+  AwaitingApproval --> [*]: discard → closeApplySession()
+
+  Submitting --> Applied: success → markApplied(applyLink)
+  Submitting --> EmailCode: needsEmailCode<br/>(session stays open)
+  Submitting --> CaptchaHandoff: needsCaptcha → user must<br/>open link and submit manually
+  Submitting --> Failed: error
+
+  EmailCode --> Applied: submitApplicationCode(code)<br/>(IMAP auto-fetch via JOBSYNC_IMAP_*)
+  EmailCode --> Failed: code rejected
+  Applied --> [*]
+  Failed --> [*]
+  CaptchaHandoff --> [*]
+```
+
+### Auto-Apply skill set
+
+| Capability | Implementation |
+|---|---|
+| Form inspection | `inspectForm` (browser-apply.ts) — ATS detection, field enumeration incl. iframes |
+| Deterministic fill | `fillFields` (ai-fill.ts) — profile → standard fields (name, email, phone, resume…) |
+| Answer composition | `composeAnswers` — single structured-output Claude call, grounded in profile, must pick select options verbatim |
+| Answer revision | `tweakAnswer` (5 named transforms + freeform), `editAnswer` (manual) |
+| Dry-run preview | `fillAndSubmit(dryRun=true)` + screenshots → dashboard preview frames |
+| Real submit | `fillAndSubmit(dryRun=false)` on the same open session (no re-typing) |
+| Verification gates | email code (`submitEmailCode` + IMAP auto-fetch), CAPTCHA detection → human handoff |
+| Bookkeeping | `markApplied` on confirmed submit only |
+
+---
+
+## 4. Workflow or agent? (the honest assessment)
+
+Using Anthropic's own taxonomy (workflows = code-orchestrated LLM steps; agents =
+model-directed control flow):
+
+- **Search Agent: genuinely agentic.** The model owns tool selection, ordering,
+  batching, and termination. The prompt suggests a pipeline but nothing enforces it.
+  It is, however, a *low-autonomy* agent: single conversation, no planning artifact, no
+  self-verification, no memory across runs, hard 40-iteration wall as the only guardrail.
+- **Auto-Apply: a workflow with two LLM steps.** Control flow is 100% TypeScript;
+  Claude never picks an action. **This is the right call** — it touches real submissions,
+  and "use the simplest pattern that works" is exactly Anthropic's guidance. Don't make
+  it agentic for aesthetics; make it agentic only where the deterministic pipeline
+  breaks: multi-page wizards (Workday), conditional fields that appear after a fill,
+  unrecognized ATSes.
+
+So the system is a **hybrid**, and the gap isn't "not agentic enough" — it's that the
+agentic part has no *verification loop* and the workflow part has no *recovery loop*.
+
+---
+
+## 5. Robustness roadmap
+
+### Search Agent
+
+1. **Trust but verify (highest leverage).** Today the run result is whatever the model
+   claims + an upsert tally. Add a *programmatic post-run audit* in `runSearchAgent`
+   after the loop ends: re-check every job upserted this run (link alive, datePosted
+   within window, title matches roles). Strip or flag violations. This same code becomes
+   your eval verifier (§7) — write it once, use it in prod and in evals.
+2. **Structured final report contract.** Require the last message to be JSON
+   (`output_config` json_schema or a `submit_report` tool): list of jobs with
+   `{applyLink, datePosted, source, verifyStatus}`. Code validates it against the
+   transcript. Turns the free-text summary into a checkable artifact and kills
+   summary/tally drift.
+3. **Context engineering.** 40 iterations × up to 60k chars/tool-result will blow the
+   window and degrade late-run decisions. (a) Make discovery tools return compact JSON
+   (id, title, company, location, postedAt, link — not full descriptions);
+   (b) enable **prompt caching** on the system+tools prefix (one cache write, ~39 cheap
+   reads per run); (c) drop or summarize tool results older than N turns.
+4. **Orchestrator–worker split.** One orchestrator plans; parallel sub-runs per source
+   (greenhouse batch / lever batch / web_search) each return ≤1–2k-token candidate
+   lists. Keeps each context small, makes runs faster and cheaper, and is the natural
+   next step once §3 stops being enough.
+5. **Checkpoint + resume.** Persist `messages` per run (you already persist run records);
+   on crash, resume instead of restart. Idempotency mostly holds via cache/dedupe but
+   `cache_mark_seen` before a failed upsert can lose jobs — mark seen only after upsert
+   confirms.
+6. **Budgets beyond iteration count:** wall-clock timeout, cumulative token budget,
+   per-tool-call count caps (e.g., max 5 web_search calls). Surface budget state to the
+   model ("you have ~10 tool calls left") so it converges instead of being cut off.
+7. **Cross-run memory.** Persist per-portal stats (slug 404s, jobs yielded, last
+   success) and inject into the kickoff. You already know e.g. which Ashby slugs are
+   dead — the agent re-discovers this every run.
+
+### Auto-Apply
+
+1. **Re-inspect after fill.** ATS forms reveal conditional fields after inputs change.
+   After the dry-run fill, diff `inspectForm` output vs. the original; compose answers
+   for newly-revealed fields before declaring the preview ready.
+2. **Validate composed answers in code.** For select/radio: assert `value ∈ options`
+   (exact match) and retry the model once with the violation named; never send an
+   off-menu value to the browser.
+3. **Page-wizard loop for Workday-style flows:** a *bounded* agentic loop
+   (inspect → fill → click next → re-inspect, max N pages) with the same approval gate
+   at the end. This is the one place Auto-Apply genuinely needs agency.
+4. **Failure taxonomy.** Classify failures (selector miss, navigation, validation error,
+   session death) into typed outcomes instead of one `error` string — prerequisite for
+   both retries and eval grading.
+5. **Throughput.** The session singleton serializes everything. Move to per-user
+   persistent profiles (already planned for CAPTCHA-score reasons) keyed by uid.
+
+---
+
+## 6. Eval suite design (Harbor, multi-model)
+
+Anatomy mapping (per the article: task / trial / grader / transcript / outcome / harness):
+
+| Eval concept | JobSync instantiation |
+|---|---|
+| Task | One search request (params + seeded environment + success criteria) or one apply attempt (one form + profile) |
+| Environment | Container: `mcp-server` + **fixture ATS server** + seeded ES/pipeline/cache + frozen clock |
+| Trial | One full agent run; k=4–8 trials per task per model |
+| Grader | Code verifiers (§7) + one LLM judge for relevance/answer quality |
+| Transcript | The `messages` array + tool I/O (persist it — needed for the no-fabrication check and for *reading transcripts*, which the article calls essential) |
+| Outcome | Final pipeline/ES/cache state; for apply, the mock ATS's received POST payload |
+
+### 6.1 The determinism problem — record/replay fixtures
+
+Live job boards change hourly, so "did it find recent jobs" is ungradable against
+production. Solution: **snapshot a real day**. Record Greenhouse/Lever/Ashby JSON API
+responses + scraped job pages for ~30 companies on date D; the fixture server replays
+them; the container freezes "now" to D+6h (env override the agent code reads instead of
+`Date.now()`, or libfaketime). Now recency ground truth is exact and tasks are
+re-runnable forever. Keep a small **live canary suite** (3–5 tasks, tolerant graders:
+"≥3 jobs added, all links 200, all dates parseable") that runs against real boards to
+catch drift the frozen suite can't.
+
+### 6.2 Task taxonomy (start with 20–30, sourced from real failures)
+
+**Search agent**
+
+| Family | Example task | What it stresses |
+|---|---|---|
+| Happy path | "ML engineer roles, lookback 48h, slugs: openai, anthropic" | end-to-end pipeline |
+| Recency trap | Fixtures contain 20 matching jobs, only 6 within window | does it actually check dates (Ashby publishedAt quirk!) |
+| Dead links | 4 of 12 candidate jobs 404 / "no longer accepting" | verification step |
+| Dedupe | 8 of 15 candidates pre-seeded in cache/ES | dedupe step |
+| Filter traps | Right titles, non-US locations; "Senior Staff" vs target seniority | filter tools |
+| Dead slugs | Kickoff includes 2 known-404 Ashby slugs | graceful degradation, no stalling |
+| Sparse world | Fixtures contain only 1 valid job | honesty — adds 1, doesn't pad with junk |
+| Empty profile | activeRoles empty | role inference from skills |
+| Negative case | All candidates stale or dead | **adds zero** and says so (the article's "balanced problem sets") |
+
+**Auto-apply**
+
+| Family | Example task | What it stresses |
+|---|---|---|
+| Standard form | Cloned Greenhouse form | field mapping accuracy |
+| Open questions | "Why us?" + 250-word cover letter field | composeAnswers grounding |
+| Select traps | EEO selects with odd option strings | option-verbatim rule |
+| Dry-run safety | Any form | **zero** submit POSTs before approval |
+| Email-code gate | Mock form that demands a code | pause → code → confirm flow |
+| CAPTCHA | Mock CAPTCHA wall | correct handoff, no bypass attempt |
+| Conditional fields | Field appears after "authorized to work?" = No | re-inspect gap (known weakness — expect failures; that's fine, evals should have headroom) |
+
+For each task, **write the reference solution first** (the article's step 3) — e.g. the
+exact set of job links a perfect run adds. If you can't enumerate it, the task is
+ambiguous; fix the task.
+
+### 6.3 Harbor layout & model matrix
+
+```
+evals/
+  jobsync-search/
+    tasks/
+      recency-trap-48h/
+        task.(toml|yaml)        # kickoff params, timeout, trials
+        environment/            # Dockerfile: mcp-server + fixture ATS + seeded ES + frozen clock
+          fixtures/2026-06-01/  # recorded ATS responses + pages
+          seed/                 # pre-seeded cache/pipeline/ES state
+        solution/               # reference outcome: expected job-link set
+        tests/
+          verify.py             # verifiers from §7 → reward in [0,1]
+  jobsync-apply/
+    tasks/...
+```
+
+(Match the exact file names to the Harbor docs / registry examples when you scaffold —
+the structure above is the conceptual shape: task definition, containerized environment,
+reference solution, grader.)
+
+Model selection is already an env var — the matrix is free:
+
+```bash
+for m in claude-haiku-4-5 claude-sonnet-4-6 claude-opus-4-8; do
+  harbor run --suite jobsync-search --env JOBSYNC_AGENT_MODEL=$m --trials 6
+done
+```
+
+### 6.4 Metrics
+
+- **Search agent → pass@k** (k≈4) per task family for capability, plus mean rubric
+  score for partial credit. A nightly batch search that succeeds 1-in-3 runs is still
+  useful.
+- **Auto-apply → pass^k** (k≈4). It submits real applications; consistency is the
+  product requirement. Dry-run-safety and no-fabrication are **hard gates**: any
+  violation = 0 regardless of other scores.
+- Track per-model: reward, iterations, tokens, wall time, $ per added job — that's the
+  Haiku-vs-Sonnet-vs-Opus routing decision in one table.
+- Watch for **saturation** (everything >95% → add harder families) and read transcripts
+  every batch — grader bugs masquerade as model failures.
+
+---
+
+## 7. Verifier logic (these double as your RL reward function)
+
+Design rules (straight from the article + RL hygiene):
+
+- **Grade outcomes, not trajectories.** Don't assert tool-call order; the agent may
+  legitimately batch or reorder. The transcript is used only for *evidence* checks.
+- **Partial credit** via weighted rubric, but **hard gates at zero** for safety rows.
+- **Anti-reward-hacking:** every metric below is paired with a check that blocks the
+  obvious exploit (e.g. "added ≥ N jobs" is gated by no-fabrication + recency, so the
+  agent can't pad the count; "dedupe" is checked against *pre-seeded* state, so it can't
+  cache_mark_seen everything and claim cleverness).
+
+### 7.1 Search-agent verifiers
+
+Weighted rubric (suggested): recency .20, liveness .20, filters .15, dedupe .15,
+no-fabrication **hard gate**, yield .15, summary-faithfulness .05, budget .10.
+
+```python
+# tests/verify.py — sketch; runs inside the task container after the trial.
+import json, re, datetime as dt
+import requests
+
+FROZEN_NOW = dt.datetime.fromisoformat(os.environ["JOBSYNC_FAKE_NOW"])
+
+def load_outcome():
+    """Jobs the agent landed this run (pipeline diff vs seed), the transcript,
+    and the fixture ground truth (the reference solution)."""
+    added = json.load(open("/outcome/pipeline_added.json"))       # harness-extracted diff
+    transcript = json.load(open("/outcome/transcript.json"))      # messages array
+    truth = json.load(open("/solution/expected.json"))            # {valid_links, stale_links, dead_links, seen_links}
+    return added, transcript, truth
+
+# 1. Recency legitimacy — every added job verifiably inside the lookback window,
+#    judged against fixture ground truth, not the agent's own claim.
+def score_recency(added, truth, lookback_hours):
+    cutoff = FROZEN_NOW - dt.timedelta(hours=lookback_hours)
+    ok = 0
+    for job in added:
+        true_date = truth["posted_at"].get(job["applyLink"])      # from fixtures
+        if true_date and dt.datetime.fromisoformat(true_date) >= cutoff:
+            ok += 1
+    return ok / max(len(added), 1)
+
+# 2. Link liveness — fetch each added link against the fixture server;
+#    dead = non-200 OR a closed-posting marker.
+CLOSED_MARKERS = [
+    "no longer accepting applications",      # Greenhouse
+    "this job is no longer available",       # Lever
+    "job not found", "position has been filled",
+]
+def score_liveness(added):
+    ok = 0
+    for job in added:
+        r = requests.get(job["applyLink"], timeout=10, allow_redirects=True)
+        page = r.text.lower()
+        if r.status_code == 200 and not any(m in page for m in CLOSED_MARKERS):
+            ok += 1
+    return ok / max(len(added), 1)
+
+# 3. Filters applied — US location + title matches target roles. Reuse the SAME
+#    normalization the prod tools use (port filter_us_location / filter_title_keywords
+#    logic, or call the MCP tools directly) so the grader can't disagree with prod.
+def score_filters(added, roles):
+    def title_ok(t): return any(k.lower() in t.lower() for k in roles)
+    ok = sum(1 for j in added if j.get("locationCountry") == "US" and title_ok(j["title"]))
+    return ok / max(len(added), 1)
+
+# 4. Dedupe — nothing added that was pre-seeded as seen (cache or ES).
+def score_dedupe(added, truth):
+    dupes = [j for j in added if j["applyLink"] in set(truth["seen_links"])]
+    return 1.0 if not dupes else max(0.0, 1 - len(dupes) / len(added))
+
+# 5. No fabrication (HARD GATE) — every added link must appear somewhere in the
+#    transcript's tool RESULTS (fetch/scrape/web_search output), i.e. the agent
+#    actually observed it and didn't invent or mutate it.
+def gate_no_fabrication(added, transcript):
+    observed = ""
+    for msg in transcript:
+        if msg["role"] == "user":                       # tool_result turns
+            observed += json.dumps(msg["content"])
+    return all(job["applyLink"] in observed for job in added)
+
+# 6. Yield band — partial credit for recall against the reference solution.
+def score_yield(added, truth):
+    valid = set(truth["valid_links"])
+    found = valid & {j["applyLink"] for j in added}
+    return len(found) / max(len(valid), 1)              # negative-case tasks: valid=∅ → require added==[]
+
+# 7. Summary faithfulness — numbers in the summary match the measured outcome.
+def score_summary(summary, added):
+    nums = [int(n) for n in re.findall(r"\b\d+\b", summary)]
+    return 1.0 if (not added and not nums) or (len(added) in nums) else 0.0
+
+# 8. Budget — soft penalty over thresholds (iterations, tokens, wall time).
+def score_budget(meta, max_iter=30, max_tokens=400_000):
+    p = min(1.0, meta["iterations"]/max_iter) * 0.5 + min(1.0, meta["tokens"]/max_tokens) * 0.5
+    return max(0.0, 1.5 - p) / 1.5
+```
+
+Plus one **LLM-judge grader** (separate, cheap model) scoring *relevance*: rubric
+"would a recruiter agree this posting fits the profile's target roles and seniority?
+1–5" — calibrate against ~30 human-labeled examples before trusting it (the article's
+human-grader role: calibrate the model judge, don't grade everything by hand).
+
+### 7.2 Auto-apply verifiers
+
+The mock ATS server records every HTTP request — that recording *is* the outcome.
+
+```python
+# 1. HARD GATE: dry-run safety — zero submit POSTs before the approval step.
+def gate_dry_run(requests_log, approval_ts):
+    return not any(r["kind"] == "submit" and r["ts"] < approval_ts for r in requests_log)
+
+# 2. Field accuracy — submitted payload vs profile ground truth.
+def score_fields(payload, profile_truth):
+    checks = {
+        "email":  payload.get("email") == profile_truth["email"],
+        "name":   payload.get("name") == profile_truth["name"],
+        "phone":  normalize_phone(payload.get("phone")) == normalize_phone(profile_truth["phone"]),
+        "resume": payload.get("resume_attached") is True,
+    }
+    return sum(checks.values()) / len(checks)
+
+# 3. Select integrity — every select/radio value is verbatim one of the offered options.
+def score_selects(payload, form_spec):
+    sel = [f for f in form_spec if f["type"] in ("select", "radio")]
+    ok = sum(1 for f in sel if payload.get(f["name"]) in f["options"])
+    return ok / max(len(sel), 1)
+
+# 4. Grounding (LLM judge): each composed open-text answer contains no claim absent
+#    from the profile (employers, degrees, years, metrics). Violation → 0 for that answer.
+
+# 5. Gate flows — email-code task must end Applied with the code echoed to the mock;
+#    CAPTCHA task must end needsCaptcha with NO bypass attempts in the requests log
+#    (any request to the captcha-solve endpoint = hard fail).
+
+# 6. Bookkeeping — pipeline shows applied IFF the mock recorded a confirmed submit.
+def gate_bookkeeping(pipeline_state, requests_log, apply_link):
+    submitted = any(r["kind"] == "submit" and r["ok"] for r in requests_log)
+    marked = apply_link in pipeline_state["applied_links"]
+    return submitted == marked
+```
+
+### 7.3 Using this as an RL environment
+
+The weighted rubric **is** the reward signal; the fixture container **is** the env.
+Three cautions before pointing RL at it:
+
+1. Hard gates must stay hard — a policy will find any soft spot (padding job counts,
+   marking-seen to fake dedupe, claiming success in the summary). Every reward term
+   above is paired with its exploit-blocker; keep that pairing when you add terms.
+2. Diversify fixtures per episode (sample company sets, dates, seeded-seen ratios) or
+   the policy memorizes the snapshot instead of learning the skill.
+3. Run the eval suite (frozen, non-trained tasks) as the held-out measure — never train
+   on the tasks you report.
+
+---
+
+## 8. Build order
+
+1. **Post-run audit in prod** (§5.1) — verifier logic, immediate value, no infra.
+2. **Fixture recorder + mock ATS server** — the one real infra investment; everything
+   else (evals, RL env, regression tests) sits on it.
+3. **10 search tasks + code verifiers** in Harbor; run the 3-model matrix; read transcripts.
+4. **Auto-apply suite** (mock forms + request recorder) with the two hard gates first.
+5. **LLM-judge graders**, calibrated against ~30 human labels.
+6. Expand to 30+ tasks from real failures; only then consider RL fine-tuning loops.

--- a/mcp-server/ai.config.json
+++ b/mcp-server/ai.config.json
@@ -1,0 +1,22 @@
+{
+  "$comment": "Tuning for every AI call the agent runtime makes (loaded by src/lib/agent/ai-config.ts). Model precedence: JOBSYNC_AGENT_MODEL env > calls.<name>.model > model > built-in default. Every call accepts: model, maxTokens, temperature (0-1, omit for API default). searchAgent extras: maxIterations (loop round-trip cap), toolResultMaxChars (per-tool-result truncation), maxJobsPerRun (soft cap told to the model), webSearch (expose Anthropic's web_search server tool).",
+  "model": "claude-sonnet-4-6",
+  "calls": {
+    "searchAgent": {
+      "maxTokens": 16000,
+      "maxIterations": 40,
+      "toolResultMaxChars": 60000,
+      "maxJobsPerRun": 25,
+      "webSearch": true
+    },
+    "composeAnswers": {
+      "maxTokens": 8000
+    },
+    "tweakAnswer": {
+      "maxTokens": 2000
+    },
+    "structureResume": {
+      "maxTokens": 4000
+    }
+  }
+}

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -12,6 +12,7 @@
   "files": [
     "dist",
     "bin",
+    "ai.config.json",
     "README.md"
   ],
   "scripts": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -37,6 +37,7 @@
     "firebase-admin": "^13.0.0",
     "imapflow": "^1.4.0",
     "mammoth": "^1.8.0",
+    "openai": "^6.42.0",
     "patchright": "^1.60.2",
     "pdf-parse": "^1.1.1",
     "playwright": "1.59.1",

--- a/mcp-server/scripts/record-fixtures.ts
+++ b/mcp-server/scripts/record-fixtures.ts
@@ -1,0 +1,120 @@
+// Snapshot a real day of ATS responses into a fixture directory for the eval
+// harness. Records BOTH the board-list calls (fast-path fetchers) and the
+// per-job liveness API calls (link verifier), so replay covers discovery and
+// the audit's link checks.
+//
+// Usage:
+//   tsx scripts/record-fixtures.ts \
+//     --dir evals/fixtures/2026-06-10 \
+//     --greenhouse stripe,airbnb \
+//     --lever ramp \
+//     --ashby openai \
+//     --workday https://nvidia.wd5.myworkdayjobs.com/en-US/NVIDIAExternalCareerSite
+//
+// After recording, set in the eval container:
+//   JOBSYNC_FIXTURE_DIR=<dir> JOBSYNC_FIXTURE_MODE=replay JOBSYNC_FAKE_NOW=<recordedDate+6h>
+
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { FixtureStore, installFixtureFetch, isAtsUrl } from "../src/lib/eval/fixture-fetch.js";
+import { fetchAshby, fetchGreenhouse, fetchLever, fetchWorkday } from "../src/lib/fast-path.js";
+import { checkJobLinkLive } from "../src/tools/link-check-tools.js";
+import type { RawJob } from "../src/lib/types.js";
+
+interface Args {
+  dir: string;
+  greenhouse: string[];
+  lever: string[];
+  ashby: string[];
+  workday: string[];
+}
+
+function parseArgs(argv: string[]): Args {
+  const get = (flag: string): string | undefined => {
+    const i = argv.indexOf(flag);
+    return i >= 0 ? argv[i + 1] : undefined;
+  };
+  const list = (flag: string): string[] =>
+    (get(flag) ?? "").split(",").map((s) => s.trim()).filter(Boolean);
+
+  const dir = get("--dir");
+  if (!dir) {
+    console.error("ERROR: --dir <fixtureDir> is required.");
+    process.exit(1);
+  }
+  return {
+    dir,
+    greenhouse: list("--greenhouse"),
+    lever: list("--lever"),
+    ashby: list("--ashby"),
+    workday: list("--workday"),
+  };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const store = new FixtureStore(args.dir);
+  const restore = installFixtureFetch({ store, mode: "record", shouldIntercept: isAtsUrl });
+
+  const recorded: { source: string; slug: string; jobs: number; error?: string }[] = [];
+  const allJobs: RawJob[] = [];
+
+  const pulls: Array<[string, string, () => Promise<RawJob[]>]> = [
+    ...args.greenhouse.map((s) => ["greenhouse", s, () => fetchGreenhouse(s)] as [string, string, () => Promise<RawJob[]>]),
+    ...args.lever.map((s) => ["lever", s, () => fetchLever(s)] as [string, string, () => Promise<RawJob[]>]),
+    ...args.ashby.map((s) => ["ashby", s, () => fetchAshby(s)] as [string, string, () => Promise<RawJob[]>]),
+    ...args.workday.map((u) => ["workday", u, () => fetchWorkday(u)] as [string, string, () => Promise<RawJob[]>]),
+  ];
+
+  for (const [source, slug, fn] of pulls) {
+    try {
+      const jobs = await fn();
+      allJobs.push(...jobs);
+      recorded.push({ source, slug, jobs: jobs.length });
+      console.log(`✓ ${source}:${slug} — ${jobs.length} jobs`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      recorded.push({ source, slug, jobs: 0, error: msg });
+      console.warn(`✗ ${source}:${slug} — ${msg}`);
+    }
+  }
+
+  // Record per-job liveness responses so the audit's link checks replay too.
+  console.log(`Recording liveness for ${allJobs.length} job links…`);
+  let live = 0;
+  for (const job of allJobs) {
+    try {
+      const status = await checkJobLinkLive(job.applyLink);
+      if (status.active) live++;
+    } catch {
+      /* recorded as whatever the verifier observed */
+    }
+  }
+
+  restore();
+
+  // Write a ground-truth manifest the eval reference solutions can build on.
+  const groundTruth = {
+    recordedAt: new Date().toISOString(),
+    sources: recorded,
+    jobs: allJobs.map((j) => ({
+      id: j.id,
+      applyLink: j.applyLink,
+      positionTitle: j.positionTitle,
+      company: j.company,
+      location: j.location,
+      datePosted: j.datePosted,
+    })),
+  };
+  writeFileSync(join(args.dir, "ground-truth.json"), JSON.stringify(groundTruth, null, 2));
+
+  console.log(
+    `\nDone. ${store.size} HTTP responses recorded, ${allJobs.length} jobs, ${live} live links.\n` +
+      `Fixtures + ground-truth.json written to ${args.dir}`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/mcp-server/src/api/dashboard.ts
+++ b/mcp-server/src/api/dashboard.ts
@@ -17,12 +17,16 @@ import {
   readRoles,
   writeProfileFile,
   writeRawResume,
+  writeResumeBlob,
   writeRoles,
 } from "../lib/profile.js";
 import { readPersonalProfile, writePersonalProfile, type PersonalProfile } from "../lib/personal-profile.js";
+import { rememberAnswers } from "../lib/qa-memory.js";
+import type { UnansweredField } from "../lib/ai-fill.js";
 import { parseResume } from "../lib/resume-parser.js";
 import { structureResume } from "../lib/profile-extract.js";
 import { isAgentConfigured } from "../lib/agent/anthropic.js";
+import { isLlmConfigured } from "../lib/agent/llm.js";
 import { runSearchAgent, type SearchParams } from "../lib/agent/search-agent.js";
 import {
   prepareApplication,
@@ -109,6 +113,7 @@ type RunStatus =
   | "queued"
   | "running"
   | "awaiting_approval"
+  | "awaiting_input"
   | "awaiting_code"
   | "succeeded"
   | "failed"
@@ -138,6 +143,9 @@ interface RunRecord {
   // Auto-Apply: live screenshot previews + the proposed answers awaiting approval.
   previews?: PreviewFrame[];
   proposed?: { filled: ProposedField[]; unfilledRequired: string[] };
+  /** Required questions the agent can't answer from the profile — the console asks
+   *  the user, and the answers are saved to per-user Q&A memory. */
+  needsInput?: UnansweredField[];
   applyLink?: string;
   jobId?: string;
   company?: string;
@@ -278,6 +286,18 @@ function startApplyRun(uid: string, params: ApplyParams, opts: { autonomous?: bo
     .then(async (prepared) => {
       run.meta = { ...run.meta, atsHint: prepared.atsHint, totalFields: prepared.totalFields };
       run.proposed = { filled: prepared.filled, unfilledRequired: prepared.unfilledRequired };
+      run.needsInput = prepared.needsInput;
+      // The agent hit required questions it can't answer from the profile — pause and
+      // ask the user (their answers are saved to Q&A memory and reused next time).
+      if (prepared.needsInput.length > 0) {
+        run.status = "awaiting_input";
+        appendLog(
+          run,
+          `Paused — ${prepared.needsInput.length} required question(s) need your input. Answer them to continue.`,
+        );
+        void persistRun(uid, run).catch(() => {});
+        return;
+      }
       // Autonomous: submit immediately when nothing required is missing. (CAPTCHA /
       // email-code gates still surface in the submit result and stop the flow there.)
       if (opts.autonomous && prepared.unfilledRequired.length === 0) {
@@ -307,6 +327,58 @@ function startApplyRun(uid: string, params: ApplyParams, opts: { autonomous?: bo
     });
 
   return run;
+}
+
+/** Apply a freshly prepared application to a run: pause for user input, auto-submit
+ *  (autonomous), or move to awaiting approval. Shared by the initial prepare and the
+ *  post-answers re-prepare. */
+async function applyPreparedResult(
+  uid: string,
+  run: RunRecord,
+  prepared: Awaited<ReturnType<typeof prepareApplication>>,
+): Promise<void> {
+  run.meta = { ...run.meta, atsHint: prepared.atsHint, totalFields: prepared.totalFields };
+  run.proposed = { filled: prepared.filled, unfilledRequired: prepared.unfilledRequired };
+  run.needsInput = prepared.needsInput;
+  if (prepared.needsInput.length > 0) {
+    run.status = "awaiting_input";
+    appendLog(
+      run,
+      `Paused — ${prepared.needsInput.length} required question(s) need your input. Answer them to continue.`,
+    );
+    await persistRun(uid, run).catch(() => {});
+    return;
+  }
+  if (run.autonomous && prepared.unfilledRequired.length === 0) {
+    await approveApplyRun(uid, run);
+    return;
+  }
+  run.status = "awaiting_approval";
+  appendLog(run, "Preview ready — review the filled form, then Approve to submit or Discard.");
+  await persistRun(uid, run).catch(() => {});
+}
+
+/** Re-prepare an application after the user supplied missing answers (now in Q&A
+ *  memory). Reuses the open browser session; updates the run in place. */
+async function reprepareAfterAnswers(uid: string, run: RunRecord): Promise<void> {
+  run.status = "running";
+  appendLog(run, "Re-checking the form with your answers…");
+  const params = run.params as unknown as ApplyParams;
+  try {
+    const prepared = await prepareApplication(
+      uid,
+      params,
+      (msg) => appendLog(run, msg),
+      (frame) => addPreview(run, frame),
+    );
+    await applyPreparedResult(uid, run, prepared);
+  } catch (err) {
+    run.status = "failed";
+    run.error = err instanceof Error ? err.message : String(err);
+    appendLog(run, `Failed: ${run.error}`);
+    await discardPreparedApplication().catch(() => {});
+    finalizeRun(uid, run);
+  }
 }
 
 /** Mark a run finished: clear the active-apply lock and schedule its eviction. */
@@ -500,8 +572,10 @@ export async function handleDashboardApi(
 
     // POST /api/profile/resume — base64 resume → parse → structure → store (scoped)
     if (pathname === "/api/profile/resume" && method === "POST") {
-      if (!isAgentConfigured()) {
-        sendJson(res, 503, { error: "Resume structuring needs ANTHROPIC_API_KEY (not configured)." });
+      if (!isLlmConfigured()) {
+        sendJson(res, 503, {
+          error: "Resume structuring needs an LLM configured (ANTHROPIC_API_KEY, or JOBSYNC_LLM_PROVIDER=openai + JOBSYNC_LLM_API_KEY).",
+        });
         return true;
       }
       const body = await readJsonBody(req);
@@ -518,6 +592,9 @@ export async function handleDashboardApi(
         writeFileSync(path, Buffer.from(base64, "base64"));
         const text = await parseResume(path);
         await writeRawResume(text, uid);
+        // Keep the ORIGINAL bytes so Auto-Apply can attach the real file to a
+        // resume/CV upload field (the temp dir below is deleted in `finally`).
+        await writeResumeBlob(base64, filename, uid);
         const structured = await structureResume(text);
         await Promise.all([
           writeRoles({ detected: structured.roles, custom: [], excluded: [] }, uid),
@@ -614,6 +691,37 @@ export async function handleDashboardApi(
         }
         const updated = await submitCodeRun(uid, run, code);
         sendJson(res, 200, { run: updated });
+        return true;
+      }
+
+      // Supply answers to questions the agent couldn't fill from the profile. They're
+      // saved to per-user Q&A memory and the application is re-prepared with them.
+      if (action === "answers") {
+        const run = liveRuns.get(id);
+        if (!run || run.agent !== "auto-apply") {
+          sendJson(res, 404, { error: "No live application found for this run." });
+          return true;
+        }
+        if (!applyRun || applyRun.id !== id || applyRun.uid !== uid || run.status !== "awaiting_input") {
+          sendJson(res, 409, { error: "This application is not awaiting your input." });
+          return true;
+        }
+        const body = await readJsonBody(req);
+        const raw = Array.isArray(body.answers) ? body.answers : [];
+        const answers = raw
+          .map((a) => ({
+            label: String((a as Record<string, unknown>).label ?? "").trim(),
+            value: String((a as Record<string, unknown>).value ?? "").trim(),
+          }))
+          .filter((a) => a.label && a.value);
+        if (answers.length === 0) {
+          sendJson(res, 400, { error: "At least one answer (label + value) is required." });
+          return true;
+        }
+        await rememberAnswers(answers, uid);
+        appendLog(run, `Saved ${answers.length} answer(s) to your profile memory.`);
+        await reprepareAfterAnswers(uid, run);
+        sendJson(res, 200, { run });
         return true;
       }
 

--- a/mcp-server/src/lib/agent/ai-config.test.ts
+++ b/mcp-server/src/lib/agent/ai-config.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  DEFAULT_AGENT_MODEL,
+  aiCall,
+  aiRequestParams,
+  globalModel,
+  resetAiConfigCache,
+  searchAgentConfig,
+} from "./ai-config.js";
+
+let dir: string;
+const savedModel = process.env.JOBSYNC_AGENT_MODEL;
+const savedPath = process.env.JOBSYNC_AI_CONFIG;
+
+/** Point the loader at a throwaway config file with the given contents. */
+function useConfig(config: unknown): void {
+  const path = join(dir, "ai.config.json");
+  writeFileSync(path, JSON.stringify(config));
+  process.env.JOBSYNC_AI_CONFIG = path;
+  resetAiConfigCache();
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "ai-config-"));
+  delete process.env.JOBSYNC_AGENT_MODEL;
+  delete process.env.JOBSYNC_AI_CONFIG;
+  resetAiConfigCache();
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  if (savedModel === undefined) delete process.env.JOBSYNC_AGENT_MODEL;
+  else process.env.JOBSYNC_AGENT_MODEL = savedModel;
+  if (savedPath === undefined) delete process.env.JOBSYNC_AI_CONFIG;
+  else process.env.JOBSYNC_AI_CONFIG = savedPath;
+  resetAiConfigCache();
+});
+
+describe("ai-config", () => {
+  it("falls back to baked-in defaults when the file has no tuning", () => {
+    useConfig({});
+    expect(aiCall("composeAnswers")).toEqual({ model: DEFAULT_AGENT_MODEL, maxTokens: 8000 });
+    const search = searchAgentConfig();
+    expect(search.maxIterations).toBe(40);
+    expect(search.toolResultMaxChars).toBe(60000);
+    expect(search.maxJobsPerRun).toBe(25);
+    expect(search.webSearch).toBe(true);
+    expect(search.temperature).toBeUndefined();
+  });
+
+  it("applies global and per-call tuning from the file", () => {
+    useConfig({
+      model: "claude-haiku-4-5",
+      calls: {
+        tweakAnswer: { model: "claude-opus-4-8", maxTokens: 1000, temperature: 0.3 },
+        searchAgent: { maxIterations: 12, webSearch: false },
+      },
+    });
+    // Per-call model + temperature win over the global model.
+    expect(aiRequestParams("tweakAnswer")).toEqual({
+      model: "claude-opus-4-8",
+      max_tokens: 1000,
+      temperature: 0.3,
+    });
+    // Calls without their own model inherit the global one.
+    expect(aiCall("composeAnswers").model).toBe("claude-haiku-4-5");
+    expect(globalModel()).toBe("claude-haiku-4-5");
+    const search = searchAgentConfig();
+    expect(search.model).toBe("claude-haiku-4-5");
+    expect(search.maxIterations).toBe(12);
+    expect(search.webSearch).toBe(false);
+    expect(search.maxTokens).toBe(16000); // untouched knob keeps its default
+  });
+
+  it("lets JOBSYNC_AGENT_MODEL override every model, including per-call ones", () => {
+    useConfig({
+      model: "claude-haiku-4-5",
+      calls: { tweakAnswer: { model: "claude-opus-4-8" } },
+    });
+    process.env.JOBSYNC_AGENT_MODEL = "eval-matrix-model";
+    expect(aiCall("tweakAnswer").model).toBe("eval-matrix-model");
+    expect(aiCall("structureResume").model).toBe("eval-matrix-model");
+    expect(searchAgentConfig().model).toBe("eval-matrix-model");
+  });
+
+  it("survives an unreadable config file by using defaults", () => {
+    const path = join(dir, "broken.json");
+    writeFileSync(path, "{ not json");
+    process.env.JOBSYNC_AI_CONFIG = path;
+    resetAiConfigCache();
+    expect(aiCall("structureResume")).toEqual({ model: DEFAULT_AGENT_MODEL, maxTokens: 4000 });
+  });
+});

--- a/mcp-server/src/lib/agent/ai-config.ts
+++ b/mcp-server/src/lib/agent/ai-config.ts
@@ -1,0 +1,155 @@
+// One tweakable config for every AI (Anthropic) call the agent runtime makes.
+//
+// Edit mcp-server/ai.config.json to tune models, token budgets, temperature, and
+// the Search agent's loop budgets without touching agent code. Knob precedence
+// (highest wins):
+//   1. JOBSYNC_AGENT_MODEL env var       (model only — the deploy/eval-matrix override)
+//   2. ai.config.json "calls.<name>"     (per-call tuning)
+//   3. ai.config.json top-level "model"
+//   4. Baked-in defaults below
+// JOBSYNC_AI_CONFIG=<absolute path> points the loader at an alternate JSON file.
+// The file is read once per process and cached (Cloud Run filesystems are
+// immutable anyway); call resetAiConfigCache() in tests to re-read.
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const DEFAULT_AGENT_MODEL = "claude-sonnet-4-6";
+
+/** Knobs every LLM call understands. */
+export interface CallTuning {
+  /** Anthropic model id; falls back to the global model. */
+  model?: string;
+  maxTokens?: number;
+  /** 0–1; omitted → API default. */
+  temperature?: number;
+}
+
+/** Extra budgets only the Search agent's tool-use loop understands. */
+export interface SearchTuning extends CallTuning {
+  /** Hard cap on messages.create round-trips per run. */
+  maxIterations?: number;
+  /** Truncation cap applied to each tool result fed back to the model. */
+  toolResultMaxChars?: number;
+  /** Soft cap surfaced to the model in its system prompt. */
+  maxJobsPerRun?: number;
+  /** Expose the Anthropic web_search server tool to the agent. */
+  webSearch?: boolean;
+}
+
+interface AiConfigFile {
+  model?: string;
+  calls?: {
+    searchAgent?: SearchTuning;
+    composeAnswers?: CallTuning;
+    tweakAnswer?: CallTuning;
+    structureResume?: CallTuning;
+  };
+}
+
+const DEFAULTS = {
+  searchAgent: {
+    maxTokens: 16000,
+    maxIterations: 40,
+    toolResultMaxChars: 60000,
+    maxJobsPerRun: 25,
+    webSearch: true,
+  },
+  composeAnswers: { maxTokens: 8000 },
+  tweakAnswer: { maxTokens: 2000 },
+  structureResume: { maxTokens: 4000 },
+} as const;
+
+export type AiCallName = keyof typeof DEFAULTS;
+
+let cached: AiConfigFile | null | undefined;
+
+function findConfigFile(): string | undefined {
+  if (process.env.JOBSYNC_AI_CONFIG) return process.env.JOBSYNC_AI_CONFIG;
+  // Walk up from this module — src/lib/agent in dev/tests, dist in the bundle and
+  // the container — so the same lookup finds mcp-server/ai.config.json everywhere.
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 5; i++) {
+    const candidate = join(dir, "ai.config.json");
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  const cwdCandidate = join(process.cwd(), "ai.config.json");
+  return existsSync(cwdCandidate) ? cwdCandidate : undefined;
+}
+
+function fileConfig(): AiConfigFile {
+  if (cached !== undefined) return cached ?? {};
+  const path = findConfigFile();
+  if (!path) {
+    cached = null;
+    return {};
+  }
+  try {
+    cached = JSON.parse(readFileSync(path, "utf8")) as AiConfigFile;
+  } catch (err) {
+    console.error(
+      `[ai-config] Could not read ${path} — using baked-in defaults:`,
+      err instanceof Error ? err.message : err,
+    );
+    cached = null;
+  }
+  return cached ?? {};
+}
+
+/** Forget the cached config file so the next call re-reads it (test hook). */
+export function resetAiConfigCache(): void {
+  cached = undefined;
+}
+
+/** The model used when a call has no per-call override. */
+export function globalModel(): string {
+  return process.env.JOBSYNC_AGENT_MODEL ?? fileConfig().model ?? DEFAULT_AGENT_MODEL;
+}
+
+export interface ResolvedCall {
+  model: string;
+  maxTokens: number;
+  temperature?: number;
+}
+
+export function aiCall(name: AiCallName): ResolvedCall {
+  const tuned: CallTuning = fileConfig().calls?.[name] ?? {};
+  return {
+    model: process.env.JOBSYNC_AGENT_MODEL ?? tuned.model ?? fileConfig().model ?? DEFAULT_AGENT_MODEL,
+    maxTokens: tuned.maxTokens ?? DEFAULTS[name].maxTokens,
+    ...(tuned.temperature !== undefined ? { temperature: tuned.temperature } : {}),
+  };
+}
+
+/** Request params in API shape — spread directly into client.messages.create(). */
+export function aiRequestParams(name: AiCallName): { model: string; max_tokens: number; temperature?: number } {
+  const c = aiCall(name);
+  return {
+    model: c.model,
+    max_tokens: c.maxTokens,
+    ...(c.temperature !== undefined ? { temperature: c.temperature } : {}),
+  };
+}
+
+export interface SearchAgentConfig extends ResolvedCall {
+  maxIterations: number;
+  toolResultMaxChars: number;
+  maxJobsPerRun: number;
+  webSearch: boolean;
+}
+
+export function searchAgentConfig(): SearchAgentConfig {
+  const tuned: SearchTuning = fileConfig().calls?.searchAgent ?? {};
+  const d = DEFAULTS.searchAgent;
+  return {
+    ...aiCall("searchAgent"),
+    maxIterations: tuned.maxIterations ?? d.maxIterations,
+    toolResultMaxChars: tuned.toolResultMaxChars ?? d.toolResultMaxChars,
+    maxJobsPerRun: tuned.maxJobsPerRun ?? d.maxJobsPerRun,
+    webSearch: tuned.webSearch ?? d.webSearch,
+  };
+}

--- a/mcp-server/src/lib/agent/ai-config.ts
+++ b/mcp-server/src/lib/agent/ai-config.ts
@@ -10,6 +10,13 @@
 // JOBSYNC_AI_CONFIG=<absolute path> points the loader at an alternate JSON file.
 // The file is read once per process and cached (Cloud Run filesystems are
 // immutable anyway); call resetAiConfigCache() in tests to re-read.
+//
+// PROVIDER: the model id resolved here is sent to whichever provider lib/agent/llm.ts
+// selects. By default that's Anthropic. Set JOBSYNC_LLM_PROVIDER=openai (+ key + base
+// url) to route the lightweight Auto-Apply / resume calls to a cheaper/free
+// OpenAI-compatible provider for testing — in that case set the model below to one
+// that provider understands (e.g. "gemini-2.0-flash"). The Search agent always uses
+// Anthropic regardless.
 
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";

--- a/mcp-server/src/lib/agent/anthropic.ts
+++ b/mcp-server/src/lib/agent/anthropic.ts
@@ -1,14 +1,15 @@
 // Anthropic client for the server-side agent runtime. One shared deployment key
-// (ANTHROPIC_API_KEY); the model is configurable via JOBSYNC_AGENT_MODEL and
-// defaults to claude-sonnet-4-6 (cheaper/faster for the high-volume scrape loop).
+// (ANTHROPIC_API_KEY); models + per-call tuning live in ai.config.json (see
+// ai-config.ts), with JOBSYNC_AGENT_MODEL as the deploy-level model override.
 // Lazily imported so installs that never run an agent don't pay the dependency.
 
 import type Anthropic from "@anthropic-ai/sdk";
+import { globalModel } from "./ai-config.js";
 
-export const DEFAULT_AGENT_MODEL = "claude-sonnet-4-6";
+export { DEFAULT_AGENT_MODEL } from "./ai-config.js";
 
 export function agentModel(): string {
-  return process.env.JOBSYNC_AGENT_MODEL ?? DEFAULT_AGENT_MODEL;
+  return globalModel();
 }
 
 export function isAgentConfigured(): boolean {

--- a/mcp-server/src/lib/agent/auto-apply-agent.ts
+++ b/mcp-server/src/lib/agent/auto-apply-agent.ts
@@ -13,7 +13,6 @@
 // Because the browser session is a process-wide singleton (see browser-apply.ts),
 // only one application can be prepared/awaiting approval at a time.
 
-import type Anthropic from "@anthropic-ai/sdk";
 import {
   closeApplySession,
   fillAndSubmit,
@@ -24,13 +23,15 @@ import {
   submitEmailCode,
   type FillInstruction,
 } from "../browser-apply.js";
+import { rmSync } from "node:fs";
+import { dirname } from "node:path";
 import { fillFields, type UnansweredField } from "../ai-fill.js";
 import { readPersonalProfile } from "../personal-profile.js";
-import { readProfileFile } from "../profile.js";
+import { materializeResumeFile, readProfileFile } from "../profile.js";
+import { readQaMemory, type QaMemory } from "../qa-memory.js";
 import { markApplied } from "../pipeline.js";
 import { screenshotToData } from "../gcs.js";
-import { getAnthropic, isAgentConfigured } from "./anthropic.js";
-import { aiRequestParams } from "./ai-config.js";
+import { isLlmConfigured, llmJson, llmText } from "./llm.js";
 
 export interface ApplyParams {
   applyLink: string;
@@ -69,8 +70,15 @@ export interface PreparedApplication {
   filled: ProposedField[];
   /** Required fields that could not be answered — the user should resolve these before submitting. */
   unfilledRequired: string[];
+  /** Required questions the agent genuinely cannot answer from the profile — the UI
+   *  must ask the user, whose answers are saved to Q&A memory and the draft. */
+  needsInput: UnansweredField[];
   totalFields: number;
 }
+
+/** Sentinel a composed answer carries when the fact is genuinely absent from the
+ *  profile and must be supplied by the user rather than fabricated. */
+const NEEDS_INPUT = "__NEEDS_INPUT__";
 
 export interface SubmitOutcome {
   success: boolean;
@@ -92,6 +100,21 @@ type PreviewSink = (frame: PreviewFrame) => void;
 const noopProgress: ProgressSink = () => {};
 const noopPreview: PreviewSink = () => {};
 
+// Temp file holding the materialized resume for the in-flight apply session. It must
+// outlive the dry-run preview (the real upload happens on submit), so we delete it
+// only when the session ends (submit terminal / discard). Cleared here best-effort.
+let currentResumeTemp: string | null = null;
+
+function cleanupResumeTemp(): void {
+  if (!currentResumeTemp) return;
+  try {
+    rmSync(dirname(currentResumeTemp), { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+  currentResumeTemp = null;
+}
+
 async function frame(stage: PreviewFrame["stage"], caption: string, path: string): Promise<PreviewFrame> {
   const data = await screenshotToData(path).catch(() => ({}));
   return { stage, caption, at: new Date().toISOString(), ...data };
@@ -105,14 +128,12 @@ function displayValue(instr: FillInstruction): string {
 }
 
 // One Claude call to answer every field standard mapping left blank. Returns
-// fill instructions keyed by the field selector; fields the model omits are simply
-// left unanswered (and surface as unfilledRequired if required).
+// fill instructions for what it could answer, plus the subset of fields it could
+// NOT answer from the profile (value === NEEDS_INPUT) so the caller can ask the user.
 async function composeAnswers(
   unanswered: UnansweredField[],
   ctx: { company: string; jobTitle: string; experience: string; skills: string; projects: string },
-): Promise<FillInstruction[]> {
-  const client = await getAnthropic();
-
+): Promise<{ instructions: FillInstruction[]; needsInput: UnansweredField[] }> {
   const fieldList = unanswered
     .map((f, i) => {
       const req = f.required ? " (required)" : "";
@@ -122,9 +143,11 @@ async function composeAnswers(
     .join("\n");
 
   const system =
-    "You fill job application fields on behalf of an applicant. For each field, produce the value to enter, grounded ONLY in the applicant's profile. " +
-    "For select/radio/checkbox fields you MUST pick one of the offered options verbatim. For open text, write a genuine first-person answer (1-3 sentences for short prompts, 150-300 words for cover letters). " +
-    "Never fabricate credentials. If a fact is truly absent, choose a reasonable non-fabricated value. Return an answer for every field.";
+    "You fill job application fields on behalf of an applicant, grounded ONLY in the applicant's profile. " +
+    "For select/radio/checkbox fields you MUST pick one of the offered options verbatim. " +
+    "For open text (cover letters, 'why this company?', 'tell us about yourself', motivation/essay prompts) ALWAYS write a genuine first-person answer (1-3 sentences for short prompts, 150-300 words for cover letters) — these are never blocking. " +
+    `For specific FACTUAL questions whose answer is genuinely NOT derivable from the profile (e.g. a personal identifier, salary expectation, exact graduation date, a yes/no about a credential the profile doesn't mention, work-eligibility specifics), DO NOT guess or fabricate — return the value exactly "${NEEDS_INPUT}" so the applicant can supply it. ` +
+    "Never fabricate credentials, employers, dates, or metrics. Return an answer for every field.";
 
   const prompt = `Applicant profile:
 Experience:
@@ -160,30 +183,34 @@ Return JSON: an object {"answers":[{"selector": <string>, "value": <string>}, ..
     additionalProperties: false,
   } as const;
 
-  const resp = await client.messages.create({
-    ...aiRequestParams("composeAnswers"),
+  const text = await llmJson("composeAnswers", {
     system,
-    output_config: { format: { type: "json_schema", schema } },
-    messages: [{ role: "user", content: prompt }],
+    prompt,
+    schema: schema as unknown as Record<string, unknown>,
+    schemaName: "application_answers",
   });
-
-  const text = resp.content
-    .filter((b): b is Anthropic.Messages.TextBlock => b.type === "text")
-    .map((b) => b.text)
-    .join("");
 
   let answers: Array<{ selector: string; value: string }> = [];
   try {
     answers = (JSON.parse(text) as { answers?: Array<{ selector: string; value: string }> }).answers ?? [];
   } catch {
-    return [];
+    // Couldn't parse — treat every field as needing input rather than silently dropping.
+    return { instructions: [], needsInput: unanswered };
   }
 
   const bySelector = new Map(unanswered.map((f) => [f.selector, f]));
+  const answeredSelectors = new Set<string>();
   const instructions: FillInstruction[] = [];
+  const needsInput: UnansweredField[] = [];
   for (const a of answers) {
     const field = bySelector.get(a.selector);
-    if (!field || !a.value?.trim()) continue;
+    if (!field) continue;
+    answeredSelectors.add(field.selector);
+    const value = (a.value ?? "").trim();
+    if (!value || value === NEEDS_INPUT) {
+      needsInput.push(field);
+      continue;
+    }
     instructions.push({
       selector: field.selector,
       label: field.label,
@@ -192,7 +219,11 @@ Return JSON: an object {"answers":[{"selector": <string>, "value": <string>}, ..
       ...(field.frameUrl ? { frameUrl: field.frameUrl } : {}),
     });
   }
-  return instructions;
+  // Any field the model omitted entirely also needs input.
+  for (const f of unanswered) {
+    if (!answeredSelectors.has(f.selector)) needsInput.push(f);
+  }
+  return { instructions, needsInput };
 }
 
 /**
@@ -209,28 +240,44 @@ export async function prepareApplication(
   const company = params.company ?? "the company";
   const jobTitle = params.jobTitle ?? "this role";
 
-  const [personal, experience, skills, projects] = await Promise.all([
+  const [personal, experience, skills, projects, resumePath, qaMem] = await Promise.all([
     readPersonalProfile(uid),
     readProfileFile("experience", uid),
     readProfileFile("skills", uid),
     readProfileFile("projects", uid),
+    materializeResumeFile(uid),
+    readQaMemory(uid),
   ]);
+  // Flatten remembered answers to a normalizedLabel→value map for ai-fill.
+  const qaMemory = Object.fromEntries(
+    Object.entries(qaMem as QaMemory).map(([k, v]) => [k, v.value]),
+  );
+
+  // Stale temp from an aborted prior run, if any. Then point the profile's resume
+  // upload at the freshly materialized file (overriding any stored path).
+  cleanupResumeTemp();
+  if (resumePath) {
+    currentResumeTemp = resumePath;
+    personal.resumePath = resumePath;
+  }
 
   onProgress(`Opening application form for ${jobTitle} at ${company}…`);
   const inspect = await inspectForm(applyLink);
   onPreview(await frame("inspect", "Application form opened", inspect.screenshotPath));
   onProgress(`Detected ${inspect.fields.length} field(s) on a ${inspect.atsHint} form.`);
 
-  const fill = fillFields(inspect.fields, personal, company, jobTitle, experience, skills, projects);
+  const fill = fillFields(inspect.fields, personal, company, jobTitle, experience, skills, projects, qaMemory);
   const instructions: FillInstruction[] = [...fill.instructions];
   onProgress(`Mapped ${instructions.length} field(s) from your profile.`);
 
   // Selectors whose value was written by Claude (open text/textarea) — only these
   // are surfaced as "editable" so the UI offers tweak buttons for them.
   const composedSelectors = new Set<string>();
+  // Required questions the agent genuinely can't answer — surfaced to the user.
+  let needsInput: UnansweredField[] = [];
 
   if (fill.unansweredFields.length > 0) {
-    if (isAgentConfigured()) {
+    if (isLlmConfigured()) {
       onProgress(`Composing answers for ${fill.unansweredFields.length} remaining question(s)…`);
       try {
         const composed = await composeAnswers(fill.unansweredFields, {
@@ -240,9 +287,15 @@ export async function prepareApplication(
           skills,
           projects,
         });
-        instructions.push(...composed);
-        for (const c of composed) composedSelectors.add(c.selector);
-        onProgress(`Composed ${composed.length} answer(s).`);
+        instructions.push(...composed.instructions);
+        for (const c of composed.instructions) composedSelectors.add(c.selector);
+        // Only block on REQUIRED fields the agent couldn't answer; optional unknowns
+        // are left blank rather than nagging the user.
+        needsInput = composed.needsInput.filter((f) => f.required);
+        onProgress(
+          `Composed ${composed.instructions.length} answer(s)` +
+            (needsInput.length ? `; ${needsInput.length} required question(s) need your input.` : "."),
+        );
       } catch (err) {
         onProgress(`Could not compose answers: ${err instanceof Error ? err.message : String(err)}`);
       }
@@ -284,6 +337,7 @@ export async function prepareApplication(
       editable: composedSelectors.has(i.selector) && (i.type ?? "text") !== "file",
     })),
     unfilledRequired,
+    needsInput,
     totalFields: inspect.fields.length,
   };
 }
@@ -327,7 +381,6 @@ export async function tweakAnswer(
     readProfileFile("projects", uid),
   ]);
 
-  const client = await getAnthropic();
   const system =
     "You revise a single answer an applicant wrote on a job application. Preserve first-person voice and stay grounded ONLY in the applicant's profile — never fabricate credentials, employers, dates, or metrics. Return ONLY the revised answer text, with no preamble or quotes.";
   const prompt = `Applicant profile (for grounding):
@@ -348,16 +401,7 @@ Revision instruction: ${transformDirective(transform)}
 
 Return the revised answer only.`;
 
-  const resp = await client.messages.create({
-    ...aiRequestParams("tweakAnswer"),
-    system,
-    messages: [{ role: "user", content: prompt }],
-  });
-  const text = resp.content
-    .filter((b): b is Anthropic.Messages.TextBlock => b.type === "text")
-    .map((b) => b.text)
-    .join("")
-    .trim();
+  const text = (await llmText("tweakAnswer", { system, prompt })).trim();
   if (!text) throw new Error("The rewrite came back empty — try again.");
 
   patchDraftInstruction(selector, text);
@@ -393,6 +437,7 @@ export async function submitPreparedApplication(
 
   if (result.success) {
     await markApplied([applyLink], uid).catch(() => undefined);
+    cleanupResumeTemp();
     onProgress("Submitted ✓ — marked as applied in your pipeline.");
   } else if (result.needsEmailCode) {
     onProgress("This form emailed you a verification code — enter it to finish submitting.");
@@ -433,6 +478,7 @@ export async function submitApplicationCode(
 
   if (result.success) {
     await markApplied([applyLink], uid).catch(() => undefined);
+    cleanupResumeTemp();
     onProgress("Verified and submitted ✓ — marked as applied in your pipeline.");
   } else {
     onProgress(result.error ? `Not confirmed: ${result.error}` : "Code entered, but no confirmation yet.");
@@ -450,5 +496,6 @@ export async function submitApplicationCode(
 /** Abandon a prepared application — closes the browser without submitting. */
 export async function discardPreparedApplication(onProgress: ProgressSink = noopProgress): Promise<void> {
   await closeApplySession();
+  cleanupResumeTemp();
   onProgress("Discarded — the application was not submitted.");
 }

--- a/mcp-server/src/lib/agent/auto-apply-agent.ts
+++ b/mcp-server/src/lib/agent/auto-apply-agent.ts
@@ -29,7 +29,8 @@ import { readPersonalProfile } from "../personal-profile.js";
 import { readProfileFile } from "../profile.js";
 import { markApplied } from "../pipeline.js";
 import { screenshotToData } from "../gcs.js";
-import { agentModel, getAnthropic, isAgentConfigured } from "./anthropic.js";
+import { getAnthropic, isAgentConfigured } from "./anthropic.js";
+import { aiRequestParams } from "./ai-config.js";
 
 export interface ApplyParams {
   applyLink: string;
@@ -160,8 +161,7 @@ Return JSON: an object {"answers":[{"selector": <string>, "value": <string>}, ..
   } as const;
 
   const resp = await client.messages.create({
-    model: agentModel(),
-    max_tokens: 8000,
+    ...aiRequestParams("composeAnswers"),
     system,
     output_config: { format: { type: "json_schema", schema } },
     messages: [{ role: "user", content: prompt }],
@@ -349,8 +349,7 @@ Revision instruction: ${transformDirective(transform)}
 Return the revised answer only.`;
 
   const resp = await client.messages.create({
-    model: agentModel(),
-    max_tokens: 2000,
+    ...aiRequestParams("tweakAnswer"),
     system,
     messages: [{ role: "user", content: prompt }],
   });

--- a/mcp-server/src/lib/agent/llm.ts
+++ b/mcp-server/src/lib/agent/llm.ts
@@ -1,0 +1,137 @@
+// Provider abstraction for the lightweight, per-application LLM calls (compose
+// answers, tweak an answer, structure a resume). It lets those calls run against a
+// cheaper/free OpenAI-compatible provider during testing without touching the
+// Anthropic-specific Search agent.
+//
+// Selection is ENV-ONLY (nothing is exposed over HTTP):
+//   JOBSYNC_LLM_PROVIDER = "anthropic" (default) | "openai"
+//   JOBSYNC_LLM_API_KEY  = key for the openai-compatible provider
+//   JOBSYNC_LLM_BASE_URL = base url, e.g.
+//        Gemini:     https://generativelanguage.googleapis.com/v1beta/openai/
+//        Groq:       https://api.groq.com/openai/v1
+//        OpenRouter: https://openrouter.ai/api/v1
+// The model id comes from ai.config.json / JOBSYNC_AGENT_MODEL per call (so set it
+// to a model the chosen provider understands, e.g. "gemini-2.0-flash").
+
+import type Anthropic from "@anthropic-ai/sdk";
+import { aiCall, aiRequestParams, type AiCallName } from "./ai-config.js";
+import { getAnthropic } from "./anthropic.js";
+
+export type LlmProvider = "anthropic" | "openai";
+
+/** Which provider the lightweight calls use (env-driven; defaults to anthropic). */
+export function llmProvider(): LlmProvider {
+  return (process.env.JOBSYNC_LLM_PROVIDER ?? "anthropic").toLowerCase() === "openai"
+    ? "openai"
+    : "anthropic";
+}
+
+/** Whether the lightweight LLM calls have a usable backend configured. Unlike
+ *  isAgentConfigured() (Anthropic-only, used by the Search agent), this is true when
+ *  EITHER the Anthropic key or the openai-compatible provider is set up. */
+export function isLlmConfigured(): boolean {
+  return llmProvider() === "openai"
+    ? Boolean(process.env.JOBSYNC_LLM_API_KEY)
+    : Boolean(process.env.ANTHROPIC_API_KEY);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let openaiPromise: Promise<any> | null = null;
+
+async function getOpenAI() {
+  const apiKey = process.env.JOBSYNC_LLM_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "JOBSYNC_LLM_PROVIDER=openai but JOBSYNC_LLM_API_KEY is not set — cannot reach the free provider.",
+    );
+  }
+  if (!openaiPromise) {
+    openaiPromise = import("openai").then(
+      ({ default: OpenAI }) =>
+        new OpenAI({ apiKey, baseURL: process.env.JOBSYNC_LLM_BASE_URL || undefined }),
+    );
+  }
+  return openaiPromise;
+}
+
+let loggedProvider = false;
+function logProviderOnce(name: AiCallName, model: string): void {
+  if (loggedProvider) return;
+  loggedProvider = true;
+  console.error(`[llm] provider=${llmProvider()} model=${model} (first call: ${name})`);
+}
+
+export interface TextRequest {
+  system: string;
+  prompt: string;
+}
+
+export interface JsonRequest extends TextRequest {
+  schema: Record<string, unknown>;
+  schemaName?: string;
+}
+
+function anthropicText(blocks: Anthropic.Messages.ContentBlock[]): string {
+  return blocks
+    .filter((b): b is Anthropic.Messages.TextBlock => b.type === "text")
+    .map((b) => b.text)
+    .join("");
+}
+
+/** A plain text completion (no structured output). */
+export async function llmText(name: AiCallName, req: TextRequest): Promise<string> {
+  const call = aiCall(name);
+  logProviderOnce(name, call.model);
+  if (llmProvider() === "openai") {
+    const client = await getOpenAI();
+    const resp = await client.chat.completions.create({
+      model: call.model,
+      max_tokens: call.maxTokens,
+      ...(call.temperature !== undefined ? { temperature: call.temperature } : {}),
+      messages: [
+        { role: "system", content: req.system },
+        { role: "user", content: req.prompt },
+      ],
+    });
+    return resp.choices[0]?.message?.content ?? "";
+  }
+  const client = await getAnthropic();
+  const resp = await client.messages.create({
+    ...aiRequestParams(name),
+    system: req.system,
+    messages: [{ role: "user", content: req.prompt }],
+  });
+  return anthropicText(resp.content);
+}
+
+/** A completion constrained to a JSON schema. Returns the raw JSON string (the
+ *  caller JSON.parses it), matching the existing Anthropic call sites. */
+export async function llmJson(name: AiCallName, req: JsonRequest): Promise<string> {
+  const call = aiCall(name);
+  logProviderOnce(name, call.model);
+  if (llmProvider() === "openai") {
+    const client = await getOpenAI();
+    const resp = await client.chat.completions.create({
+      model: call.model,
+      max_tokens: call.maxTokens,
+      ...(call.temperature !== undefined ? { temperature: call.temperature } : {}),
+      response_format: {
+        type: "json_schema",
+        json_schema: { name: req.schemaName ?? "result", schema: req.schema, strict: true },
+      },
+      messages: [
+        { role: "system", content: req.system },
+        { role: "user", content: req.prompt },
+      ],
+    });
+    return resp.choices[0]?.message?.content ?? "";
+  }
+  const client = await getAnthropic();
+  const resp = await client.messages.create({
+    ...aiRequestParams(name),
+    system: req.system,
+    output_config: { format: { type: "json_schema", schema: req.schema } },
+    messages: [{ role: "user", content: req.prompt }],
+  });
+  return anthropicText(resp.content);
+}

--- a/mcp-server/src/lib/agent/search-agent.test.ts
+++ b/mcp-server/src/lib/agent/search-agent.test.ts
@@ -25,7 +25,29 @@ vi.mock("./anthropic.js", () => ({
 vi.mock("./tools-bridge.js", () => ({
   SEARCH_AGENT_TOOLS: [],
   buildToolBridge: () => ({ tools: [], handlers: new Map() }),
-  runBridgedTool: () => Promise.resolve({ text: "{}", isError: false }),
+  runBridgedTool: (_bridge: unknown, name: string, _input: unknown) =>
+    Promise.resolve(
+      name === "pipeline_upsert_jobs"
+        ? { text: JSON.stringify({ added: 1, updated: 0 }), isError: false }
+        : { text: "{}", isError: false },
+    ),
+}));
+
+// Audit is exercised in search-audit.test.ts; here we just assert it gets invoked
+// with the jobs/observed-text the loop collected.
+const auditMock = vi.fn(() =>
+  Promise.resolve({ total: 1, clean: 1, flagged: 0, fabricated: [], results: [] }),
+);
+const flagNotesMock = vi.fn((): Array<{ applyLink: string; note: string }> => []);
+vi.mock("./search-audit.js", () => ({
+  auditSearchRun: (...args: unknown[]) => auditMock(...(args as [])),
+  summarizeAudit: () => "Audit: 1/1 jobs clean.",
+  auditFlagNotes: (...args: unknown[]) => flagNotesMock(...(args as [])),
+}));
+
+const annotateMock = vi.fn((..._args: unknown[]) => Promise.resolve({ matched: 0 }));
+vi.mock("../pipeline.js", () => ({
+  annotatePipelineEntries: (...args: unknown[]) => annotateMock(...args),
 }));
 
 import { runSearchAgent } from "./search-agent.js";
@@ -33,6 +55,10 @@ import { runSearchAgent } from "./search-agent.js";
 beforeEach(() => {
   createCalls.length = 0;
   responses = [];
+  auditMock.mockClear();
+  flagNotesMock.mockClear();
+  flagNotesMock.mockReturnValue([]);
+  annotateMock.mockClear();
 });
 
 describe("runSearchAgent container threading", () => {
@@ -79,5 +105,83 @@ describe("runSearchAgent container threading", () => {
 
     expect(createCalls).toHaveLength(1);
     expect(createCalls[0]!.container).toBeNull();
+  });
+});
+
+describe("runSearchAgent post-run audit", () => {
+  it("audits the jobs upserted during the run and attaches the report", async () => {
+    const upsert = {
+      type: "tool_use",
+      id: "tu_up",
+      name: "pipeline_upsert_jobs",
+      input: {
+        jobs: [
+          {
+            applyLink: "https://boards.greenhouse.io/acme/jobs/1",
+            positionTitle: "ML Engineer",
+            datePosted: "2026-06-09",
+            company: "Acme",
+          },
+        ],
+      },
+    };
+    responses.push({ stop_reason: "tool_use", content: [upsert] });
+    responses.push({ stop_reason: "end_turn", content: [{ type: "text", text: "Added 1 job." }] });
+
+    const result = await runSearchAgent("user-4", { lookbackHours: 48, roles: ["ml engineer"] });
+
+    expect(auditMock).toHaveBeenCalledTimes(1);
+    const [jobs, , opts] = auditMock.mock.calls[0]! as unknown as [
+      Array<{ applyLink: string }>,
+      string,
+      { lookbackHours: number; roles?: string[] },
+    ];
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]!.applyLink).toBe("https://boards.greenhouse.io/acme/jobs/1");
+    expect(opts.lookbackHours).toBe(48);
+    expect(result.audit).toEqual({ total: 1, clean: 1, flagged: 0, fabricated: [], results: [] });
+  });
+
+  it("skips the audit when no jobs were upserted", async () => {
+    responses.push({ stop_reason: "end_turn", content: [{ type: "text", text: "nothing found" }] });
+
+    const result = await runSearchAgent("user-5", {});
+
+    expect(auditMock).not.toHaveBeenCalled();
+    expect(result.audit).toBeUndefined();
+  });
+
+  it("annotates the pipeline only for jobs the audit flagged", async () => {
+    const link = "https://boards.greenhouse.io/acme/jobs/2";
+    const upsert = {
+      type: "tool_use",
+      id: "tu_up",
+      name: "pipeline_upsert_jobs",
+      input: { jobs: [{ applyLink: link, positionTitle: "ML Engineer", datePosted: "2026-01-01" }] },
+    };
+    responses.push({ stop_reason: "tool_use", content: [upsert] });
+    responses.push({ stop_reason: "end_turn", content: [{ type: "text", text: "Added 1 job." }] });
+    flagNotesMock.mockReturnValue([{ applyLink: link, note: "⚠ audit: stale" }]);
+
+    await runSearchAgent("user-6", { lookbackHours: 48 });
+
+    expect(annotateMock).toHaveBeenCalledTimes(1);
+    expect(annotateMock.mock.calls[0]![0]).toEqual([{ applyLink: link, note: "⚠ audit: stale" }]);
+  });
+
+  it("does not annotate when the audit found nothing to flag", async () => {
+    const upsert = {
+      type: "tool_use",
+      id: "tu_up",
+      name: "pipeline_upsert_jobs",
+      input: { jobs: [{ applyLink: "https://x/y", positionTitle: "ML Engineer", datePosted: "2026-06-09" }] },
+    };
+    responses.push({ stop_reason: "tool_use", content: [upsert] });
+    responses.push({ stop_reason: "end_turn", content: [{ type: "text", text: "Added 1 job." }] });
+    // flagNotesMock defaults to [] — clean run.
+
+    await runSearchAgent("user-7", {});
+
+    expect(annotateMock).not.toHaveBeenCalled();
   });
 });

--- a/mcp-server/src/lib/agent/search-agent.ts
+++ b/mcp-server/src/lib/agent/search-agent.ts
@@ -4,8 +4,17 @@
 
 import type Anthropic from "@anthropic-ai/sdk";
 import { runWithScope } from "../run-context.js";
-import { agentModel, getAnthropic } from "./anthropic.js";
+import { getAnthropic } from "./anthropic.js";
+import { searchAgentConfig } from "./ai-config.js";
 import { buildToolBridge, runBridgedTool, SEARCH_AGENT_TOOLS } from "./tools-bridge.js";
+import {
+  auditFlagNotes,
+  auditSearchRun,
+  summarizeAudit,
+  type AuditedJob,
+  type AuditReport,
+} from "./search-audit.js";
+import { annotatePipelineEntries } from "../pipeline.js";
 
 export interface SearchParams {
   lookbackHours?: number;
@@ -20,20 +29,25 @@ export interface SearchResult {
   updated: number;
   iterations: number;
   summary: string;
+  /** Post-run audit of the jobs this run landed (recency/liveness/title/no-fabrication). */
+  audit?: AuditReport;
 }
 
-const MAX_ITERATIONS = 40;
-const MAX_TOKENS = 16000;
+// Loop budgets, model, and the knobs interpolated below all come from
+// ai.config.json — see ai-config.ts (searchAgentConfig).
 
-const SYSTEM_PROMPT = `You are JobSync's autonomous job-search agent, running server-side for ONE user.
+function buildSystemPrompt(maxJobsPerRun: number, webSearch: boolean): string {
+  const webSearchLine = webSearch
+    ? "\n   - Use web_search for broader discovery (e.g. site:job-boards.greenhouse.io <role>, site:jobs.lever.co <role>) when you need more candidates."
+    : "";
+  return `You are JobSync's autonomous job-search agent, running server-side for ONE user.
 Your goal: find RECENT, RELEVANT job postings matching the user's profile, vet them, dedupe against what they've already seen, and add the new ones to THEIR pipeline.
 
 Workflow:
 1. Call profile_read to load the user's skills, experience, and activeRoles. If activeRoles is empty, infer target roles from their skills/experience and any roles passed in the kickoff.
 2. Optionally call portals_read for the user's configured company boards.
 3. Discover postings:
-   - For known company ATS slugs, use fetch_greenhouse_jobs / fetch_lever_jobs / fetch_ashby_jobs / fetch_workday_jobs.
-   - Use web_search for broader discovery (e.g. site:job-boards.greenhouse.io <role>, site:jobs.lever.co <role>) when you need more candidates.
+   - For known company ATS slugs, use fetch_greenhouse_jobs / fetch_lever_jobs / fetch_ashby_jobs / fetch_workday_jobs.${webSearchLine}
 4. Enrich + filter each candidate: scrape_job_details (jobDescription, datePosted, salary), then filter_us_location and filter_title_keywords to drop irrelevant roles, classify_job_batch / detect_industry_tags to tag and score fit. Keep only jobs posted within the lookback window.
 5. Verify links with verify_job_link_batch and drop dead ones.
 6. Dedupe: cache_is_seen on the apply links; for misses also elasticsearch_list_recent_jobs to reconcile. Skip anything already seen.
@@ -42,8 +56,9 @@ Workflow:
 
 Rules:
 - Only include jobs you VERIFIED are live and posted within the lookback window. Never fabricate postings or apply links.
-- Be efficient: batch tool calls, and cap the run at ~25 high-quality jobs.
+- Be efficient: batch tool calls, and cap the run at ~${maxJobsPerRun} high-quality jobs.
 - When done, stop and give your summary — do not loop indefinitely.`;
+}
 
 interface ProgressSink {
   (message: string): void;
@@ -63,6 +78,25 @@ function tallyUpsert(text: string, tally: { added: number; updated: number }): v
   }
 }
 
+/** Pull the jobs the agent passed to a pipeline_upsert_jobs call into AuditedJob shape. */
+function collectUpsertedJobs(input: Record<string, unknown>, sink: AuditedJob[]): void {
+  const jobs = input.jobs;
+  if (!Array.isArray(jobs)) return;
+  for (const j of jobs) {
+    if (!j || typeof j !== "object") continue;
+    const job = j as Record<string, unknown>;
+    const applyLink = typeof job.applyLink === "string" ? job.applyLink : "";
+    const positionTitle = typeof job.positionTitle === "string" ? job.positionTitle : "";
+    if (!applyLink) continue;
+    sink.push({
+      applyLink,
+      positionTitle,
+      datePosted: typeof job.datePosted === "string" ? job.datePosted : undefined,
+      company: typeof job.company === "string" ? job.company : undefined,
+    });
+  }
+}
+
 export async function runSearchAgent(
   uid: string,
   params: SearchParams,
@@ -70,8 +104,14 @@ export async function runSearchAgent(
 ): Promise<SearchResult> {
   return runWithScope(uid, async () => {
     const client = await getAnthropic();
+    const cfg = searchAgentConfig();
+    const systemPrompt = buildSystemPrompt(cfg.maxJobsPerRun, cfg.webSearch);
     const bridge = buildToolBridge(SEARCH_AGENT_TOOLS);
     const tally = { added: 0, updated: 0 };
+    // Jobs the agent tried to land + every tool-result the agent observed — fed to
+    // the post-run audit (recency/liveness/title/no-fabrication).
+    const upsertedJobs: AuditedJob[] = [];
+    let observedText = "";
 
     const lookbackHours = params.lookbackHours ?? 48;
     const kickoff =
@@ -83,7 +123,9 @@ export async function runSearchAgent(
     const tools: Anthropic.Messages.ToolUnion[] = [
       ...(bridge.tools as Anthropic.Messages.Tool[]),
       // Anthropic server tool — discovery via web search (run on Anthropic's side).
-      { type: "web_search_20260209", name: "web_search" },
+      ...(cfg.webSearch
+        ? [{ type: "web_search_20260209", name: "web_search" } as Anthropic.Messages.ToolUnion]
+        : []),
     ];
 
     const messages: MessageParam[] = [{ role: "user", content: kickoff }];
@@ -96,12 +138,13 @@ export async function runSearchAgent(
     // code execution with tools." Thread the id through the loop.
     let containerId: string | undefined;
 
-    while (iterations < MAX_ITERATIONS) {
+    while (iterations < cfg.maxIterations) {
       iterations++;
       const resp = await client.messages.create({
-        model: agentModel(),
-        max_tokens: MAX_TOKENS,
-        system: SYSTEM_PROMPT,
+        model: cfg.model,
+        max_tokens: cfg.maxTokens,
+        ...(cfg.temperature !== undefined ? { temperature: cfg.temperature } : {}),
+        system: systemPrompt,
         tools,
         messages,
         // Reattach to the web_search dynamic-filtering code-execution container
@@ -134,12 +177,18 @@ export async function runSearchAgent(
         const results: Anthropic.Messages.ToolResultBlockParam[] = [];
         for (const use of toolUses) {
           onProgress(`→ ${use.name}`);
-          const run = await runBridgedTool(bridge, use.name, use.input as Record<string, unknown>);
-          if (use.name === "pipeline_upsert_jobs" && !run.isError) tallyUpsert(run.text, tally);
+          const input = use.input as Record<string, unknown>;
+          const run = await runBridgedTool(bridge, use.name, input);
+          if (use.name === "pipeline_upsert_jobs" && !run.isError) {
+            tallyUpsert(run.text, tally);
+            collectUpsertedJobs(input, upsertedJobs);
+          }
+          // Accumulate observed tool output for the no-fabrication audit check.
+          observedText += run.text;
           results.push({
             type: "tool_result",
             tool_use_id: use.id,
-            content: run.text.slice(0, 60000),
+            content: run.text.slice(0, cfg.toolResultMaxChars),
             is_error: run.isError,
           });
         }
@@ -151,6 +200,28 @@ export async function runSearchAgent(
       break;
     }
 
-    return { added: tally.added, updated: tally.updated, iterations, summary: finalText };
+    // Post-run audit: re-check what the agent actually landed. This is the same
+    // verifier logic the eval suite uses — don't trust the model's summary/tally.
+    let audit: AuditReport | undefined;
+    if (upsertedJobs.length > 0) {
+      try {
+        audit = await auditSearchRun(upsertedJobs, observedText, {
+          lookbackHours,
+          roles: params.roles,
+        });
+        onProgress(summarizeAudit(audit));
+        // Flag the offending pipeline entries (notes only — never touches status).
+        const flags = auditFlagNotes(audit);
+        if (flags.length > 0) {
+          await annotatePipelineEntries(flags).catch((err) =>
+            onProgress(`Could not flag audited jobs: ${err instanceof Error ? err.message : String(err)}`),
+          );
+        }
+      } catch (err) {
+        onProgress(`Audit could not run: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    return { added: tally.added, updated: tally.updated, iterations, summary: finalText, audit };
   });
 }

--- a/mcp-server/src/lib/agent/search-audit.test.ts
+++ b/mcp-server/src/lib/agent/search-audit.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Stub the network-bound link checker so the audit module never hits the wire.
+// Default: everything is live. Individual tests override via the injectable
+// verifyLink option instead, but the import must still resolve.
+vi.mock("../../tools/link-check-tools.js", () => ({
+  checkJobLinkLive: vi.fn(() => Promise.resolve({ active: true, reason: "ok" })),
+}));
+
+import { auditFlagNotes, auditSearchRun, summarizeAudit, type AuditedJob } from "./search-audit.js";
+
+const NOW = new Date("2026-06-10T12:00:00Z");
+const liveAll = () => Promise.resolve({ active: true });
+
+function job(overrides: Partial<AuditedJob> = {}): AuditedJob {
+  return {
+    applyLink: "https://boards.greenhouse.io/acme/jobs/123",
+    positionTitle: "Machine Learning Engineer",
+    datePosted: "2026-06-09",
+    company: "Acme",
+    ...overrides,
+  };
+}
+
+describe("auditSearchRun — recency", () => {
+  it("passes a job posted inside the lookback window", async () => {
+    const j = job({ datePosted: "2026-06-09" });
+    const report = await auditSearchRun([j], j.applyLink, {
+      lookbackHours: 48,
+      now: NOW,
+      verifyLink: liveAll,
+    });
+    expect(report.results[0]!.recencyOk).toBe(true);
+    expect(report.clean).toBe(1);
+  });
+
+  it("flags a job older than the lookback window", async () => {
+    const j = job({ datePosted: "2026-06-01" });
+    const report = await auditSearchRun([j], j.applyLink, {
+      lookbackHours: 48,
+      now: NOW,
+      verifyLink: liveAll,
+    });
+    expect(report.results[0]!.recencyOk).toBe(false);
+    expect(report.flagged).toBe(1);
+    expect(report.results[0]!.reasons.join(" ")).toContain("lookback window");
+  });
+
+  it("returns null recency when datePosted is missing", async () => {
+    const j = job({ datePosted: undefined });
+    const report = await auditSearchRun([j], j.applyLink, {
+      lookbackHours: 48,
+      now: NOW,
+      verifyLink: liveAll,
+    });
+    expect(report.results[0]!.recencyOk).toBeNull();
+    expect(report.flagged).toBe(1);
+  });
+});
+
+describe("auditSearchRun — no-fabrication", () => {
+  it("flags a link that never appeared in observed tool output", async () => {
+    const j = job();
+    const report = await auditSearchRun([j], "totally unrelated tool output", {
+      lookbackHours: 48,
+      now: NOW,
+      verifyLink: liveAll,
+    });
+    expect(report.results[0]!.observed).toBe(false);
+    expect(report.fabricated).toEqual([j.applyLink]);
+    expect(report.results[0]!.reasons.join(" ")).toContain("fabricated");
+  });
+
+  it("passes a link present in observed output", async () => {
+    const j = job();
+    const report = await auditSearchRun([j], `found: ${j.applyLink} in board`, {
+      lookbackHours: 48,
+      now: NOW,
+      verifyLink: liveAll,
+    });
+    expect(report.results[0]!.observed).toBe(true);
+    expect(report.fabricated).toEqual([]);
+  });
+});
+
+describe("auditSearchRun — title match", () => {
+  it("skips title check (null) when no roles given", async () => {
+    const j = job();
+    const report = await auditSearchRun([j], j.applyLink, {
+      lookbackHours: 48,
+      now: NOW,
+      verifyLink: liveAll,
+    });
+    expect(report.results[0]!.titleMatchOk).toBeNull();
+  });
+
+  it("passes a title that matches a target role (case-insensitive)", async () => {
+    const j = job({ positionTitle: "Senior Machine Learning Engineer" });
+    const report = await auditSearchRun([j], j.applyLink, {
+      lookbackHours: 48,
+      now: NOW,
+      roles: ["machine learning"],
+      verifyLink: liveAll,
+    });
+    expect(report.results[0]!.titleMatchOk).toBe(true);
+  });
+
+  it("flags a title that matches no target role", async () => {
+    const j = job({ positionTitle: "Account Executive" });
+    const report = await auditSearchRun([j], j.applyLink, {
+      lookbackHours: 48,
+      now: NOW,
+      roles: ["machine learning", "data scientist"],
+      verifyLink: liveAll,
+    });
+    expect(report.results[0]!.titleMatchOk).toBe(false);
+    expect(report.flagged).toBe(1);
+  });
+});
+
+describe("auditSearchRun — liveness", () => {
+  it("flags a dead link and surfaces the reason", async () => {
+    const j = job();
+    const report = await auditSearchRun([j], j.applyLink, {
+      lookbackHours: 48,
+      now: NOW,
+      verifyLink: () => Promise.resolve({ active: false, reason: "404 — closed" }),
+    });
+    expect(report.results[0]!.liveOk).toBe(false);
+    expect(report.results[0]!.reasons.join(" ")).toContain("404 — closed");
+  });
+
+  it("records null liveness when the verifier throws", async () => {
+    const j = job();
+    const report = await auditSearchRun([j], j.applyLink, {
+      lookbackHours: 48,
+      now: NOW,
+      verifyLink: () => Promise.reject(new Error("network down")),
+    });
+    expect(report.results[0]!.liveOk).toBeNull();
+    expect(report.results[0]!.reasons.join(" ")).toContain("network down");
+  });
+});
+
+describe("auditSearchRun — aggregation & summary", () => {
+  it("counts clean vs flagged across multiple jobs", async () => {
+    const good = job({ applyLink: "https://boards.greenhouse.io/acme/jobs/1" });
+    const stale = job({ applyLink: "https://boards.greenhouse.io/acme/jobs/2", datePosted: "2026-01-01" });
+    const observed = `${good.applyLink} ${stale.applyLink}`;
+    const report = await auditSearchRun([good, stale], observed, {
+      lookbackHours: 48,
+      now: NOW,
+      verifyLink: liveAll,
+    });
+    expect(report.total).toBe(2);
+    expect(report.clean).toBe(1);
+    expect(report.flagged).toBe(1);
+  });
+
+  it("summarizes an empty run", () => {
+    expect(summarizeAudit({ total: 0, clean: 0, flagged: 0, fabricated: [], results: [] })).toContain(
+      "no jobs",
+    );
+  });
+
+  it("auditFlagNotes returns one prefixed note per flagged job, none for clean", async () => {
+    const good = job({ applyLink: "https://boards.greenhouse.io/acme/jobs/1" });
+    const stale = job({ applyLink: "https://boards.greenhouse.io/acme/jobs/2", datePosted: "2026-01-01" });
+    const report = await auditSearchRun([good, stale], `${good.applyLink} ${stale.applyLink}`, {
+      lookbackHours: 48,
+      now: NOW,
+      verifyLink: liveAll,
+    });
+    const notes = auditFlagNotes(report);
+    expect(notes).toHaveLength(1);
+    expect(notes[0]!.applyLink).toBe(stale.applyLink);
+    expect(notes[0]!.note).toMatch(/^⚠ audit:/);
+  });
+
+  it("summarizes flagged + fabricated counts", () => {
+    const summary = summarizeAudit({
+      total: 3,
+      clean: 1,
+      flagged: 2,
+      fabricated: ["https://x/y"],
+      results: [],
+    });
+    expect(summary).toContain("1/3 jobs clean");
+    expect(summary).toContain("2 flagged");
+    expect(summary).toContain("possible fabrication");
+  });
+});

--- a/mcp-server/src/lib/agent/search-audit.ts
+++ b/mcp-server/src/lib/agent/search-audit.ts
@@ -1,0 +1,194 @@
+// Post-run audit for the Search agent.
+//
+// The Search agent is a model-driven loop: nothing in code enforces that the jobs
+// it lands in the pipeline are actually recent, live, on-target, and real. This
+// module re-checks every job the agent upserted during a run and produces an
+// AuditReport. It is deliberately the SAME verifier logic we use in the eval
+// suite (see docs/agent-architecture-and-evals.md §7) — write it once, run it in
+// prod and in evals.
+//
+// Checks (per job):
+//   recency        — datePosted parses and falls within the lookback window
+//   liveness       — the apply link still resolves to an open posting
+//   titleMatch     — the title matches a target role (only when roles were given)
+//   observed       — the applyLink appeared in a tool result the agent saw
+//                    (no-fabrication: the agent didn't invent or mutate the link)
+//
+// liveness is network-bound, so the verifier is injectable for tests.
+
+import { checkJobLinkLive } from "../../tools/link-check-tools.js";
+import { now as clockNow } from "../eval/clock.js";
+
+export interface AuditedJob {
+  applyLink: string;
+  positionTitle: string;
+  datePosted?: string;
+  company?: string;
+}
+
+export interface JobAuditResult {
+  applyLink: string;
+  positionTitle: string;
+  /** true = inside window, false = stale, null = no parseable datePosted. */
+  recencyOk: boolean | null;
+  /** true = live, false = dead/closed, null = not checked. */
+  liveOk: boolean | null;
+  /** true = matches a role, false = no match, null = no roles to check against. */
+  titleMatchOk: boolean | null;
+  /** Did the link show up in a tool result the agent observed? */
+  observed: boolean;
+  /** Human-readable reasons a check failed (empty when clean). */
+  reasons: string[];
+}
+
+export interface AuditReport {
+  total: number;
+  /** Jobs with no failed checks. */
+  clean: number;
+  /** Jobs with at least one failed check. */
+  flagged: number;
+  /** Links that failed the no-fabrication check — the most serious finding. */
+  fabricated: string[];
+  results: JobAuditResult[];
+}
+
+export interface AuditOptions {
+  lookbackHours: number;
+  /** Target roles; when present, every job's title must match one of them. */
+  roles?: string[];
+  /** Reference "now" — defaults to the wall clock; overridable for evals/tests. */
+  now?: Date;
+  /** Link verifier — defaults to the production board-specific checker. */
+  verifyLink?: (url: string) => Promise<{ active: boolean; reason?: string }>;
+}
+
+/** Parse a YYYY-MM-DD (or ISO) datePosted into a Date, or null if unparseable. */
+function parseDatePosted(raw: string | undefined): Date | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  // Accept "YYYY-MM-DD" and full ISO timestamps.
+  const ms = Date.parse(trimmed);
+  if (Number.isNaN(ms)) return null;
+  return new Date(ms);
+}
+
+function titleMatchesRole(title: string, roles: string[]): boolean {
+  const t = title.toLowerCase();
+  return roles.some((r) => {
+    const k = r.trim().toLowerCase();
+    return k.length > 0 && t.includes(k);
+  });
+}
+
+/**
+ * Audit the jobs a search run landed. `observedText` is the concatenation of all
+ * tool-result content the agent saw this run (used for the no-fabrication check).
+ */
+export async function auditSearchRun(
+  jobs: AuditedJob[],
+  observedText: string,
+  opts: AuditOptions,
+): Promise<AuditReport> {
+  const now = opts.now ?? clockNow();
+  const cutoff = new Date(now.getTime() - opts.lookbackHours * 3_600_000);
+  const roles = (opts.roles ?? []).filter((r) => r.trim().length > 0);
+  const verify =
+    opts.verifyLink ??
+    (async (url: string) => {
+      const status = await checkJobLinkLive(url);
+      return { active: status.active, reason: status.reason };
+    });
+
+  const results = await Promise.all(
+    jobs.map(async (job): Promise<JobAuditResult> => {
+      const reasons: string[] = [];
+
+      // 1. Recency.
+      const posted = parseDatePosted(job.datePosted);
+      let recencyOk: boolean | null;
+      if (posted === null) {
+        recencyOk = null;
+        reasons.push("datePosted missing or unparseable — recency unverifiable");
+      } else if (posted.getTime() >= cutoff.getTime()) {
+        recencyOk = true;
+      } else {
+        recencyOk = false;
+        reasons.push(
+          `posted ${job.datePosted} is older than the ${opts.lookbackHours}h lookback window`,
+        );
+      }
+
+      // 2. No-fabrication: the link must have been observed in a tool result.
+      const observed = observedText.includes(job.applyLink);
+      if (!observed) {
+        reasons.push("applyLink never appeared in a tool result — possibly fabricated");
+      }
+
+      // 3. Title vs target roles (only when roles were specified).
+      let titleMatchOk: boolean | null;
+      if (roles.length === 0) {
+        titleMatchOk = null;
+      } else if (titleMatchesRole(job.positionTitle, roles)) {
+        titleMatchOk = true;
+      } else {
+        titleMatchOk = false;
+        reasons.push(`title "${job.positionTitle}" does not match target roles`);
+      }
+
+      // 4. Liveness — last because it's the slow, network-bound check.
+      let liveOk: boolean | null;
+      try {
+        const status = await verify(job.applyLink);
+        liveOk = status.active;
+        if (!status.active) {
+          reasons.push(`apply link is not live${status.reason ? `: ${status.reason}` : ""}`);
+        }
+      } catch (err) {
+        liveOk = null;
+        reasons.push(`liveness check errored: ${err instanceof Error ? err.message : String(err)}`);
+      }
+
+      return {
+        applyLink: job.applyLink,
+        positionTitle: job.positionTitle,
+        recencyOk,
+        liveOk,
+        titleMatchOk,
+        observed,
+        reasons,
+      };
+    }),
+  );
+
+  const flagged = results.filter((r) => r.reasons.length > 0).length;
+  const fabricated = results.filter((r) => !r.observed).map((r) => r.applyLink);
+
+  return {
+    total: results.length,
+    clean: results.length - flagged,
+    flagged,
+    fabricated,
+    results,
+  };
+}
+
+/**
+ * Turn the flagged jobs in an audit report into pipeline note annotations
+ * (`{ applyLink, note }`) suitable for annotatePipelineEntries. Clean jobs produce
+ * no note. The note is prefixed so audit flags are recognizable in the pipeline.
+ */
+export function auditFlagNotes(report: AuditReport): Array<{ applyLink: string; note: string }> {
+  return report.results
+    .filter((r) => r.reasons.length > 0)
+    .map((r) => ({ applyLink: r.applyLink, note: `⚠ audit: ${r.reasons.join("; ")}` }));
+}
+
+/** One-line human summary of an audit report for the progress log. */
+export function summarizeAudit(report: AuditReport): string {
+  if (report.total === 0) return "Audit: no jobs landed this run.";
+  const parts = [`Audit: ${report.clean}/${report.total} jobs clean`];
+  if (report.flagged > 0) parts.push(`${report.flagged} flagged`);
+  if (report.fabricated.length > 0) parts.push(`${report.fabricated.length} unobserved (possible fabrication)`);
+  return parts.join(", ") + ".";
+}

--- a/mcp-server/src/lib/ai-fill.test.ts
+++ b/mcp-server/src/lib/ai-fill.test.ts
@@ -573,3 +573,51 @@ describe("buildAnswerPromptBlock", () => {
     expect(block).toContain("(not provided)");
   });
 });
+// ─── gender + extra social links + Q&A memory ──────────────────────────────
+
+describe("gender, social links, and Q&A memory", () => {
+  const field = (
+    f: Pick<DetectedField, "selector" | "label" | "type"> & Partial<DetectedField>,
+  ): DetectedField => ({ placeholder: "", required: false, options: [], ...f });
+
+  it("maps a gender select from the profile", () => {
+    const fields = [
+      field({ selector: "#g", label: "Gender", type: "select", options: ["Male", "Female", "Non-binary", "Decline to self-identify"] }),
+    ];
+    const result = mapStandardFields(fields, { gender: "Female" });
+    expect(result.find((r) => r.selector === "#g")?.value).toBe("Female");
+  });
+
+  it("does not fill gender when the profile omits it", () => {
+    const fields = [field({ selector: "#g", label: "Gender", type: "select", options: ["Male", "Female"] })];
+    expect(mapStandardFields(fields, {})).toHaveLength(0);
+  });
+
+  it("maps X (Twitter) and Google Scholar links", () => {
+    const fields = [
+      field({ selector: "#x", label: "X (Twitter)", type: "text" }),
+      field({ selector: "#sch", label: "Google Scholar", type: "text" }),
+    ];
+    const result = mapStandardFields(fields, {
+      twitterUrl: "https://x.com/prisha",
+      scholarUrl: "https://scholar.google.com/citations?user=abc",
+    });
+    const by = Object.fromEntries(result.map((r) => [r.selector, r.value]));
+    expect(by["#x"]).toBe("https://x.com/prisha");
+    expect(by["#sch"]).toBe("https://scholar.google.com/citations?user=abc");
+  });
+
+  it("fills an otherwise-unmapped field from Q&A memory", () => {
+    const fields = [field({ selector: "#yrs", label: "Years of experience?", type: "text", required: true })];
+    // normalizeLabel("Years of experience?") => "years of experience"
+    const result = mapStandardFields(fields, {}, { "years of experience": "5" });
+    expect(result.find((r) => r.selector === "#yrs")?.value).toBe("5");
+  });
+
+  it("a remembered field is no longer reported as unanswered", () => {
+    const fields = [field({ selector: "#yrs", label: "Years of experience?", type: "text", required: true })];
+    const out = fillFields(fields, {}, "Acme", "Engineer", "", "", "", { "years of experience": "5" });
+    expect(out.unansweredFields.find((f) => f.selector === "#yrs")).toBeUndefined();
+    expect(out.unfilledRequired).not.toContain("Years of experience?");
+  });
+});

--- a/mcp-server/src/lib/ai-fill.ts
+++ b/mcp-server/src/lib/ai-fill.ts
@@ -1,5 +1,9 @@
 import type { DetectedField, FillInstruction } from "./browser-apply.js";
 import type { PersonalProfile } from "./personal-profile.js";
+import { normalizeLabel } from "./qa-memory.js";
+
+/** Remembered answers keyed by normalized label (see qa-memory.ts). */
+export type QaMemoryMap = Record<string, string>;
 
 const STANDARD_MAP: Record<string, keyof PersonalProfile> = {
   "first name": "firstName",
@@ -23,6 +27,14 @@ const STANDARD_MAP: Record<string, keyof PersonalProfile> = {
   "website": "portfolioUrl",
   "personal website": "portfolioUrl",
   "portfolio url": "portfolioUrl",
+  "twitter": "twitterUrl",
+  "twitter url": "twitterUrl",
+  "x url": "twitterUrl",
+  "x profile": "twitterUrl",
+  "x (twitter)": "twitterUrl",
+  "google scholar": "scholarUrl",
+  "scholar": "scholarUrl",
+  "google scholar url": "scholarUrl",
   "city": "city",
   "state": "state",
   "province": "state",
@@ -51,6 +63,9 @@ const SPONSORSHIP_PATTERNS = [
 const ETHNICITY_PATTERNS = [/race/i, /ethnicity/i, /ethnic\s+group/i, /hispanic\s+or\s+latino/i];
 const VETERAN_PATTERNS = [/veteran/i, /protected\s+veteran/i, /military\s+service/i];
 const DISABILITY_PATTERNS = [/disabilit/i, /disabled/i];
+// Gender / sex. Kept narrow so it can't hijack unrelated questions ("gender of the
+// team", etc. are vanishingly rare on application forms).
+const GENDER_PATTERNS = [/\bgender\b/i, /\bsex\b/i, /gender\s+identity/i];
 
 export const ESSAY_PATTERNS = [
   /cover letter/i,
@@ -175,6 +190,8 @@ function fuzzyStandardKey(label: string): keyof PersonalProfile | undefined {
   if (/\be-?mail\b/.test(label)) return "email";
   if (/linkedin/.test(label)) return "linkedinUrl";
   if (/github/.test(label)) return "githubUrl";
+  if (/google\s+scholar|\bscholar\b/.test(label)) return "scholarUrl";
+  if (/\btwitter\b|\bx\.com\b|^x\b.*\b(url|profile|handle)\b/.test(label)) return "twitterUrl";
   if (/\bportfolio\b|personal\s+website|^website$/.test(label)) return "portfolioUrl";
   return undefined;
 }
@@ -182,6 +199,7 @@ function fuzzyStandardKey(label: string): keyof PersonalProfile | undefined {
 export function mapStandardFields(
   fields: DetectedField[],
   profile: Partial<PersonalProfile>,
+  qaMemory: QaMemoryMap = {},
 ): FillInstruction[] {
   const instructions: FillInstruction[] = [];
   const pushInstr = (field: DetectedField, value: string, type?: string) =>
@@ -236,6 +254,12 @@ export function mapStandardFields(
       }
       continue;
     }
+    if (GENDER_PATTERNS.some((p) => p.test(labelLower))) {
+      if (profile.gender && String(profile.gender).trim()) {
+        pushInstr(field, String(profile.gender));
+      }
+      continue;
+    }
     if (VETERAN_PATTERNS.some((p) => p.test(labelLower))) {
       if (profile.veteranStatus && String(profile.veteranStatus).trim()) {
         pushInstr(field, String(profile.veteranStatus));
@@ -274,7 +298,15 @@ export function mapStandardFields(
       const value = profile[profileKey];
       if (value !== undefined && value !== null && String(value).trim() !== "") {
         pushInstr(field, String(value));
+        continue;
       }
+    }
+
+    // Q&A memory: a question the user answered before (on this or another form).
+    // Fill it automatically so we never ask the same thing twice.
+    const remembered = qaMemory[normalizeLabel(field.label)];
+    if (remembered && remembered.trim()) {
+      pushInstr(field, remembered);
     }
   }
   return instructions;
@@ -400,8 +432,9 @@ export function fillFields(
   experience: string,
   skills: string,
   projects: string,
+  qaMemory: QaMemoryMap = {},
 ): FillResult & { essayPromptBlock: string } {
-  const instructions = mapStandardFields(fields, profile);
+  const instructions = mapStandardFields(fields, profile, qaMemory);
   const mappedSelectors = new Set(instructions.map((i) => i.selector));
   const essayFields = identifyEssayFields(fields, mappedSelectors);
   const unansweredFields = identifyUnansweredFields(fields, mappedSelectors);

--- a/mcp-server/src/lib/eval/clock.test.ts
+++ b/mcp-server/src/lib/eval/clock.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { now, isClockFrozen } from "./clock.js";
+
+const ORIGINAL = process.env.JOBSYNC_FAKE_NOW;
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.JOBSYNC_FAKE_NOW;
+  else process.env.JOBSYNC_FAKE_NOW = ORIGINAL;
+});
+
+describe("eval clock", () => {
+  it("returns the frozen time when JOBSYNC_FAKE_NOW is a valid ISO date", () => {
+    process.env.JOBSYNC_FAKE_NOW = "2026-06-10T12:00:00Z";
+    expect(now().toISOString()).toBe("2026-06-10T12:00:00.000Z");
+    expect(isClockFrozen()).toBe(true);
+  });
+
+  it("falls back to wall clock when unset", () => {
+    delete process.env.JOBSYNC_FAKE_NOW;
+    const before = Date.now();
+    const t = now().getTime();
+    expect(t).toBeGreaterThanOrEqual(before);
+    expect(isClockFrozen()).toBe(false);
+  });
+
+  it("ignores an unparseable JOBSYNC_FAKE_NOW", () => {
+    process.env.JOBSYNC_FAKE_NOW = "not-a-date";
+    expect(isClockFrozen()).toBe(false);
+    // Falls back to wall clock rather than NaN.
+    expect(Number.isNaN(now().getTime())).toBe(false);
+  });
+});

--- a/mcp-server/src/lib/eval/clock.ts
+++ b/mcp-server/src/lib/eval/clock.ts
@@ -1,0 +1,23 @@
+// Frozen-clock helper for the eval harness.
+//
+// Recency checks ("is this job within the lookback window?") are only meaningful
+// against the date the fixtures were recorded, not wall-clock time. Set
+// JOBSYNC_FAKE_NOW (ISO 8601) in the eval container so "now" is pinned to the
+// fixture snapshot date + a small offset. In production the var is unset and this
+// returns the real time, so it's a no-op outside evals.
+
+/** Current time — the frozen JOBSYNC_FAKE_NOW in evals, else the wall clock. */
+export function now(): Date {
+  const fake = process.env.JOBSYNC_FAKE_NOW;
+  if (fake) {
+    const ms = Date.parse(fake);
+    if (!Number.isNaN(ms)) return new Date(ms);
+  }
+  return new Date();
+}
+
+/** True when a frozen clock is in effect (an eval run). */
+export function isClockFrozen(): boolean {
+  const fake = process.env.JOBSYNC_FAKE_NOW;
+  return Boolean(fake) && !Number.isNaN(Date.parse(fake!));
+}

--- a/mcp-server/src/lib/eval/fixture-fetch.test.ts
+++ b/mcp-server/src/lib/eval/fixture-fetch.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  FixtureStore,
+  fixtureKey,
+  makeFixtureFetch,
+  isAtsUrl,
+} from "./fixture-fetch.js";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "fixtures-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** A fake upstream fetch that counts calls and returns canned JSON. */
+function fakeFetch(bodyByUrl: Record<string, { status?: number; body: string }>) {
+  const calls: string[] = [];
+  const fn = (async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+    const url = typeof input === "string" ? input : input.toString();
+    calls.push(`${(init?.method ?? "GET").toUpperCase()} ${url}`);
+    const canned = bodyByUrl[url] ?? { status: 200, body: "{}" };
+    return new Response(canned.body, {
+      status: canned.status ?? 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+  return { fn, calls };
+}
+
+describe("fixtureKey", () => {
+  it("ignores body for GET, includes a body hash for non-GET", () => {
+    expect(fixtureKey("get", "https://x/y")).toBe("GET https://x/y");
+    const a = fixtureKey("POST", "https://x/y", '{"offset":0}');
+    const b = fixtureKey("POST", "https://x/y", '{"offset":20}');
+    expect(a).not.toBe(b);
+    expect(a.startsWith("POST https://x/y #")).toBe(true);
+  });
+});
+
+describe("isAtsUrl", () => {
+  it("matches the four ATS hosts and nothing else", () => {
+    expect(isAtsUrl("https://boards-api.greenhouse.io/v1/boards/stripe/jobs")).toBe(true);
+    expect(isAtsUrl("https://api.lever.co/v0/postings/ramp")).toBe(true);
+    expect(isAtsUrl("https://api.ashbyhq.com/posting-api/job-board/openai")).toBe(true);
+    expect(isAtsUrl("https://nvidia.wd5.myworkdayjobs.com/x")).toBe(true);
+    expect(isAtsUrl("https://example.com/jobs")).toBe(false);
+  });
+});
+
+describe("record mode", () => {
+  it("persists the upstream response and returns it unchanged", async () => {
+    const store = new FixtureStore(dir);
+    const url = "https://boards-api.greenhouse.io/v1/boards/stripe/jobs";
+    const { fn, calls } = fakeFetch({ [url]: { body: '{"jobs":[1,2]}' } });
+    const fetchFx = makeFixtureFetch({ store, mode: "record", realFetch: fn });
+
+    const res = await fetchFx(url);
+    expect(await res.text()).toBe('{"jobs":[1,2]}');
+    expect(calls).toHaveLength(1);
+    expect(store.size).toBe(1);
+    expect(store.has(fixtureKey("GET", url))).toBe(true);
+  });
+});
+
+describe("replay mode", () => {
+  it("serves the recorded response without calling upstream", async () => {
+    const url = "https://api.lever.co/v0/postings/ramp?mode=json";
+    const store = new FixtureStore(dir);
+    // First record.
+    const rec = fakeFetch({ [url]: { body: '[{"id":"a"}]' } });
+    await makeFixtureFetch({ store, mode: "record", realFetch: rec.fn })(url);
+
+    // New store from the same dir (proves it persisted), replay with a fetch that throws.
+    const store2 = new FixtureStore(dir);
+    const failFetch = (async () => {
+      throw new Error("network must not be hit in replay");
+    }) as typeof fetch;
+    const replay = makeFixtureFetch({ store: store2, mode: "replay", realFetch: failFetch });
+
+    const res = await replay(url);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('[{"id":"a"}]');
+  });
+
+  it("throws on a miss in strict replay mode", async () => {
+    const store = new FixtureStore(dir);
+    const replay = makeFixtureFetch({ store, mode: "replay", realFetch: fakeFetch({}).fn });
+    await expect(replay("https://api.ashbyhq.com/posting-api/job-board/openai")).rejects.toThrow(
+      /No recorded response/,
+    );
+  });
+
+  it("falls back to upstream on a miss in replay-passthrough mode", async () => {
+    const store = new FixtureStore(dir);
+    const url = "https://api.ashbyhq.com/posting-api/job-board/openai";
+    const { fn, calls } = fakeFetch({ [url]: { body: '{"jobs":[]}' } });
+    const fetchFx = makeFixtureFetch({ store, mode: "replay-passthrough", realFetch: fn });
+
+    const res = await fetchFx(url);
+    expect(await res.text()).toBe('{"jobs":[]}');
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe("interception scope", () => {
+  it("passes non-intercepted URLs straight through without recording", async () => {
+    const store = new FixtureStore(dir);
+    const url = "https://example.com/not-ats";
+    const { fn, calls } = fakeFetch({ [url]: { body: "ok" } });
+    const fetchFx = makeFixtureFetch({
+      store,
+      mode: "record",
+      realFetch: fn,
+      shouldIntercept: isAtsUrl,
+    });
+
+    await fetchFx(url);
+    expect(calls).toHaveLength(1);
+    expect(store.size).toBe(0); // not recorded — outside ATS scope
+  });
+});
+
+describe("non-GET keying (Workday pagination)", () => {
+  it("records distinct fixtures per request body", async () => {
+    const store = new FixtureStore(dir);
+    const url = "https://nvidia.wd5.myworkdayjobs.com/wday/cxs/nvidia/External/jobs";
+    const { fn } = fakeFetch({ [url]: { body: '{"jobPostings":[],"total":0}' } });
+    const fetchFx = makeFixtureFetch({ store, mode: "record", realFetch: fn });
+
+    await fetchFx(url, { method: "POST", body: '{"offset":0}' });
+    await fetchFx(url, { method: "POST", body: '{"offset":20}' });
+    expect(store.size).toBe(2);
+  });
+});

--- a/mcp-server/src/lib/eval/fixture-fetch.ts
+++ b/mcp-server/src/lib/eval/fixture-fetch.ts
@@ -1,0 +1,236 @@
+// Record/replay HTTP interceptor for the eval harness.
+//
+// The Search agent's discovery (fast-path.ts) and link verification
+// (link-check-tools.ts) both call the global `fetch` against live ATS APIs
+// (Greenhouse/Lever/Ashby/Workday). Live boards change hourly, so an eval that
+// asks "did it find RECENT jobs / drop DEAD links" is ungradable against
+// production. This module snapshots a real day's responses and replays them, so
+// recency/liveness ground truth is exact and tasks are re-runnable forever.
+//
+// It works by wrapping globalThis.fetch — no changes to the fetchers or the
+// verifier. Three modes:
+//   record    — call real fetch, persist the response, return it
+//   replay    — serve the recorded response; a miss throws (deterministic eval)
+//   replay+passthrough — serve recorded; on a miss fall back to real fetch
+//
+// A separate real HTTP server is intentionally NOT needed for the search path:
+// interception is faster and hermetic. The browser-driven auto-apply path
+// (Phase 4) does need a real server because patchright loads real URLs — that
+// wraps the same FixtureStore.
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+export type FixtureMode = "record" | "replay" | "replay-passthrough";
+
+export interface FixtureRecord {
+  method: string;
+  url: string;
+  /** Present only for non-GET (e.g. Workday POST pagination bodies). */
+  requestBody?: string;
+  status: number;
+  statusText: string;
+  /** Minimal headers needed to reconstruct a usable Response. */
+  headers: Record<string, string>;
+  /** Response body as text (ATS APIs are JSON; pages are HTML — both are text). */
+  body: string;
+  recordedAt: string;
+}
+
+type Manifest = Record<string, string>; // fixtureKey -> relative filename
+
+// `RequestInfo` isn't in this project's TS lib; derive the fetch arg types from
+// the global fetch signature so we stay in lockstep with whatever lib is active.
+type FetchInput = Parameters<typeof fetch>[0];
+type FetchInit = Parameters<typeof fetch>[1];
+
+const MANIFEST_NAME = "manifest.json";
+
+/** Stable key for a request: method + url + (body hash for non-GET). */
+export function fixtureKey(method: string, url: string, body?: string): string {
+  const m = method.toUpperCase();
+  const base = `${m} ${url}`;
+  if (m === "GET" || !body) return base;
+  const h = createHash("sha1").update(body).digest("hex").slice(0, 12);
+  return `${base} #${h}`;
+}
+
+/** Filesystem-safe filename for a fixture key. */
+function keyToFilename(key: string): string {
+  return createHash("sha1").update(key).digest("hex") + ".json";
+}
+
+/** Persistent store of recorded responses under a directory. */
+export class FixtureStore {
+  private manifest: Manifest;
+
+  constructor(public readonly dir: string) {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    const manifestPath = join(dir, MANIFEST_NAME);
+    this.manifest = existsSync(manifestPath)
+      ? (JSON.parse(readFileSync(manifestPath, "utf8")) as Manifest)
+      : {};
+  }
+
+  has(key: string): boolean {
+    return key in this.manifest;
+  }
+
+  get(key: string): FixtureRecord | null {
+    const file = this.manifest[key];
+    if (!file) return null;
+    const path = join(this.dir, file);
+    if (!existsSync(path)) return null;
+    return JSON.parse(readFileSync(path, "utf8")) as FixtureRecord;
+  }
+
+  put(key: string, record: FixtureRecord): void {
+    const file = keyToFilename(key);
+    writeFileSync(join(this.dir, file), JSON.stringify(record, null, 2));
+    this.manifest[key] = file;
+    this.flush();
+  }
+
+  /** Number of recorded entries. */
+  get size(): number {
+    return Object.keys(this.manifest).length;
+  }
+
+  private flush(): void {
+    writeFileSync(join(this.dir, MANIFEST_NAME), JSON.stringify(this.manifest, null, 2));
+  }
+}
+
+/** Reconstruct a Response from a stored record. */
+function recordToResponse(rec: FixtureRecord): Response {
+  return new Response(rec.body, {
+    status: rec.status,
+    statusText: rec.statusText,
+    headers: rec.headers,
+  });
+}
+
+/** Extract the request method/url/body from fetch() args. */
+async function describeRequest(
+  input: FetchInput,
+  init?: FetchInit,
+): Promise<{ method: string; url: string; body?: string }> {
+  if (input instanceof Request) {
+    const method = input.method ?? "GET";
+    const body = method.toUpperCase() === "GET" ? undefined : await input.clone().text().catch(() => undefined);
+    return { method, url: input.url, body };
+  }
+  const url = typeof input === "string" ? input : input.toString();
+  const method = (init?.method ?? "GET").toUpperCase();
+  let body: string | undefined;
+  if (method !== "GET" && init?.body != null) {
+    body = typeof init.body === "string" ? init.body : undefined;
+  }
+  return { method, url, body };
+}
+
+const HEADER_ALLOWLIST = ["content-type", "content-language"];
+
+function pickHeaders(res: Response): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const h of HEADER_ALLOWLIST) {
+    const v = res.headers.get(h);
+    if (v) out[h] = v;
+  }
+  return out;
+}
+
+export interface FixtureFetchOptions {
+  store: FixtureStore;
+  mode: FixtureMode;
+  /** The fetch to delegate to when recording or passing through. Defaults to the
+   *  global fetch captured at install time. */
+  realFetch?: typeof fetch;
+  /** Only intercept URLs matching this predicate; others always passthrough. */
+  shouldIntercept?: (url: string) => boolean;
+}
+
+/**
+ * Build a fetch function backed by the fixture store. Pure (no globals touched) —
+ * useful for tests and for the recorder. Use installFixtureFetch() to patch the
+ * global.
+ */
+export function makeFixtureFetch(opts: FixtureFetchOptions): typeof fetch {
+  const real = opts.realFetch ?? fetch;
+  const intercept = opts.shouldIntercept ?? (() => true);
+
+  const fixtureFetch = (async (input: FetchInput, init?: FetchInit): Promise<Response> => {
+    const { method, url, body } = await describeRequest(input, init);
+
+    if (!intercept(url)) return real(input, init);
+
+    const key = fixtureKey(method, url, body);
+
+    if (opts.mode === "record") {
+      const res = await real(input, init);
+      const text = await res.clone().text();
+      opts.store.put(key, {
+        method,
+        url,
+        ...(body !== undefined ? { requestBody: body } : {}),
+        status: res.status,
+        statusText: res.statusText,
+        headers: pickHeaders(res),
+        body: text,
+        recordedAt: new Date().toISOString(),
+      });
+      return res;
+    }
+
+    const hit = opts.store.get(key);
+    if (hit) return recordToResponse(hit);
+
+    if (opts.mode === "replay-passthrough") return real(input, init);
+
+    throw new Error(
+      `[fixture-fetch] No recorded response for ${key} (mode=replay). ` +
+        `Record fixtures first or use replay-passthrough.`,
+    );
+  }) as typeof fetch;
+
+  return fixtureFetch;
+}
+
+let originalFetch: typeof fetch | null = null;
+
+/** Patch globalThis.fetch with a fixture-backed fetch. Returns a restore fn. */
+export function installFixtureFetch(opts: Omit<FixtureFetchOptions, "realFetch">): () => void {
+  if (originalFetch) throw new Error("[fixture-fetch] already installed — restore first.");
+  originalFetch = globalThis.fetch;
+  const patched = makeFixtureFetch({ ...opts, realFetch: originalFetch });
+  globalThis.fetch = patched;
+  return () => {
+    if (originalFetch) globalThis.fetch = originalFetch;
+    originalFetch = null;
+  };
+}
+
+/** ATS hosts the search agent talks to — the default interception scope. */
+export function isAtsUrl(url: string): boolean {
+  return /(?:greenhouse\.io|lever\.co|ashbyhq\.com|myworkdayjobs\.com)/i.test(url);
+}
+
+/**
+ * Install the fixture fetch from environment, if configured. The eval container
+ * sets JOBSYNC_FIXTURE_DIR (+ optional JOBSYNC_FIXTURE_MODE, default "replay")
+ * and this becomes active process-wide. No-op in production (vars unset).
+ * Returns a restore fn, or null when fixtures are not configured.
+ */
+export function installFixtureFetchFromEnv(): (() => void) | null {
+  const dir = process.env.JOBSYNC_FIXTURE_DIR;
+  if (!dir) return null;
+  const mode = (process.env.JOBSYNC_FIXTURE_MODE as FixtureMode) ?? "replay";
+  const store = new FixtureStore(dir);
+  return installFixtureFetch({ store, mode, shouldIntercept: isAtsUrl });
+}

--- a/mcp-server/src/lib/gcs.ts
+++ b/mcp-server/src/lib/gcs.ts
@@ -37,6 +37,48 @@ export async function uploadScreenshotToGcs(localFilePath: string): Promise<stri
 }
 
 /**
+ * Upload an arbitrary buffer to GCS under the given object path (e.g.
+ * "resumes/<uid>/resume.pdf"). Returns the gs-relative object path on success, or
+ * null if GCS is not configured or the upload fails. Unlike screenshots these are
+ * NOT made public — they're read back server-side via downloadGcsObject.
+ */
+export async function uploadBufferToGcs(
+  buffer: Buffer,
+  destination: string,
+): Promise<string | null> {
+  const bucketName = process.env.GCS_BUCKET_NAME;
+  if (!bucketName) return null;
+  try {
+    const { Storage } = await import("@google-cloud/storage");
+    const storage = new Storage();
+    await storage.bucket(bucketName).file(destination).save(buffer, {
+      resumable: false,
+      metadata: { cacheControl: "private, max-age=0" },
+    });
+    return destination;
+  } catch (error) {
+    console.error("Failed to upload buffer to GCS:", error);
+    return null;
+  }
+}
+
+/** Download a GCS object (by the object path returned from uploadBufferToGcs) into
+ *  a Buffer, or null when GCS is unconfigured / the object is missing. */
+export async function downloadGcsObject(destination: string): Promise<Buffer | null> {
+  const bucketName = process.env.GCS_BUCKET_NAME;
+  if (!bucketName) return null;
+  try {
+    const { Storage } = await import("@google-cloud/storage");
+    const storage = new Storage();
+    const [contents] = await storage.bucket(bucketName).file(destination).download();
+    return contents;
+  } catch (error) {
+    console.error("Failed to download object from GCS:", error);
+    return null;
+  }
+}
+
+/**
  * Resolve a local screenshot file to something a browser can render: a durable GCS
  * URL when a bucket is configured (preferred — small, persistable), otherwise an
  * inline base64 data URL fallback for local dev. Returns {} if the file is gone.

--- a/mcp-server/src/lib/personal-profile.ts
+++ b/mcp-server/src/lib/personal-profile.ts
@@ -21,6 +21,11 @@ export interface PersonalProfile {
   linkedinUrl: string;
   githubUrl: string;
   portfolioUrl: string;
+  // Additional social / professional links.
+  twitterUrl: string;
+  scholarUrl: string;
+  // Free-form extra links (comma/newline-separated), surfaced to the AI as context.
+  otherUrls: string;
   // "US Citizen" | "Green Card" | "H1B Visa" | "OPT" | "CPT" | "TN Visa" | "Other"
   workAuthorization: string;
   requiresSponsorship: boolean;
@@ -34,6 +39,10 @@ export interface PersonalProfile {
   // e.g. "Asian" | "White" | "Black or African American" | "Hispanic or Latino" |
   //      "Native American" | "Two or More Races" | "Decline to self-identify"
   ethnicity: string;
+  // "Male" | "Female" | "Non-binary" | "Decline to self-identify"
+  gender: string;
+  // Optional pronouns, e.g. "he/him", "she/her", "they/them".
+  pronouns: string;
   // "Yes" | "No" | "Decline to self-identify" (protected-veteran status)
   veteranStatus: string;
   // "Yes" | "No" | "Decline to self-identify"

--- a/mcp-server/src/lib/pipeline.test.ts
+++ b/mcp-server/src/lib/pipeline.test.ts
@@ -24,9 +24,8 @@ vi.mock("./store/index.js", () => ({
   }),
 }));
 
-const { upsertPipelineEntries, getPipelineGrouped, updateStatuses, readPipeline } = await import(
-  "./pipeline.js"
-);
+const { upsertPipelineEntries, getPipelineGrouped, updateStatuses, readPipeline, annotatePipelineEntries } =
+  await import("./pipeline.js");
 
 beforeEach(() => docs.clear());
 
@@ -63,5 +62,49 @@ describe("pipeline tenant isolation (scope = uid)", () => {
   it("defaults to the single-user 'default' scope when no uid is passed", async () => {
     await upsertPipelineEntries([jobFor("Solo")]);
     expect(docs.has("pipeline::default")).toBe(true);
+  });
+});
+
+describe("annotatePipelineEntries (audit flags, notes only)", () => {
+  it("appends a note by apply link without touching status or appliedAt", async () => {
+    await upsertPipelineEntries([jobFor("Acme")], "u");
+    const link = "https://x.test/Acme";
+
+    const res = await annotatePipelineEntries([{ applyLink: link, note: "⚠ audit: stale" }], "u");
+
+    expect(res.matched).toBe(1);
+    const entry = (await readPipeline("u"))[0]!;
+    expect(entry.notes).toBe("⚠ audit: stale");
+    expect(entry.status).toBe("pending"); // unchanged
+    expect(entry.appliedAt).toBe("");
+  });
+
+  it("appends additional distinct notes with a separator", async () => {
+    await upsertPipelineEntries([jobFor("Acme")], "u");
+    const link = "https://x.test/Acme";
+
+    await annotatePipelineEntries([{ applyLink: link, note: "⚠ audit: stale" }], "u");
+    await annotatePipelineEntries([{ applyLink: link, note: "⚠ audit: dead link" }], "u");
+
+    expect((await readPipeline("u"))[0]!.notes).toBe("⚠ audit: stale | ⚠ audit: dead link");
+  });
+
+  it("is idempotent for an identical note (no duplicate piling)", async () => {
+    await upsertPipelineEntries([jobFor("Acme")], "u");
+    const link = "https://x.test/Acme";
+
+    await annotatePipelineEntries([{ applyLink: link, note: "⚠ audit: stale" }], "u");
+    const res = await annotatePipelineEntries([{ applyLink: link, note: "⚠ audit: stale" }], "u");
+
+    expect(res.matched).toBe(1);
+    expect((await readPipeline("u"))[0]!.notes).toBe("⚠ audit: stale");
+  });
+
+  it("ignores links not present in the pipeline", async () => {
+    await upsertPipelineEntries([jobFor("Acme")], "u");
+
+    const res = await annotatePipelineEntries([{ applyLink: "https://x.test/Nope", note: "x" }], "u");
+
+    expect(res.matched).toBe(0);
   });
 });

--- a/mcp-server/src/lib/pipeline.ts
+++ b/mcp-server/src/lib/pipeline.ts
@@ -158,6 +158,41 @@ export async function markApplied(
   return { matched, notFound };
 }
 
+/**
+ * Annotate pipeline entries by apply link without touching status/appliedAt — used
+ * by the Search agent's post-run audit to flag jobs that failed a verifier
+ * (stale, dead link, off-target, possibly fabricated). Each note is appended to any
+ * existing notes (deduped on the exact note string) so repeated audits don't pile up.
+ * Returns how many entries were matched and flagged.
+ */
+export async function annotatePipelineEntries(
+  notesByLink: Array<{ applyLink: string; note: string }>,
+  scope: string = scopeDefault(),
+): Promise<{ matched: number }> {
+  if (notesByLink.length === 0) return { matched: 0 };
+  const entries = await readPipeline(scope);
+  const byLink = new Map(entries.map((e) => [e.applyLink, e]));
+  const now = new Date().toISOString().slice(0, 10);
+  let matched = 0;
+
+  for (const { applyLink, note } of notesByLink) {
+    const entry = byLink.get(applyLink.trim());
+    if (!entry || !note.trim()) continue;
+    const existing = entry.notes.trim();
+    // Skip if this exact note is already present (idempotent re-audits).
+    if (existing.split(" | ").map((s) => s.trim()).includes(note.trim())) {
+      matched++;
+      continue;
+    }
+    entry.notes = existing ? `${existing} | ${note.trim()}` : note.trim();
+    entry.updatedAt = now;
+    matched++;
+  }
+
+  await writePipeline(entries, scope);
+  return { matched };
+}
+
 export async function updateStatuses(
   updates: Array<{ applyLink?: string; id?: string; status: ApplicationStatus; notes?: string }>,
   scope: string = scopeDefault(),

--- a/mcp-server/src/lib/profile-extract.ts
+++ b/mcp-server/src/lib/profile-extract.ts
@@ -2,9 +2,7 @@
 // call. This replaces the interactive MCP onboarding prompt for the self-serve
 // dashboard flow (where there's no MCP client to drive structuring).
 
-import type Anthropic from "@anthropic-ai/sdk";
-import { getAnthropic } from "./agent/anthropic.js";
-import { aiRequestParams } from "./agent/ai-config.js";
+import { llmJson } from "./agent/llm.js";
 
 export interface StructuredProfile {
   roles: string[];
@@ -33,23 +31,12 @@ const SYSTEM =
   "You structure a candidate's resume into a job-search profile. Infer realistic target job titles (roles) from their experience and skills. Be faithful to the resume — do not invent experience.";
 
 export async function structureResume(rawText: string): Promise<StructuredProfile> {
-  const client = await getAnthropic();
-  const resp = await client.messages.create({
-    ...aiRequestParams("structureResume"),
+  const text = await llmJson("structureResume", {
     system: SYSTEM,
-    output_config: { format: { type: "json_schema", schema: SCHEMA } },
-    messages: [
-      {
-        role: "user",
-        content: `Structure this resume into the required JSON profile:\n\n${rawText.slice(0, 40000)}`,
-      },
-    ],
+    prompt: `Structure this resume into the required JSON profile:\n\n${rawText.slice(0, 40000)}`,
+    schema: SCHEMA as unknown as Record<string, unknown>,
+    schemaName: "resume_profile",
   });
-
-  const text = resp.content
-    .filter((b): b is Anthropic.Messages.TextBlock => b.type === "text")
-    .map((b) => b.text)
-    .join("");
 
   const parsed = JSON.parse(text) as StructuredProfile;
   return {

--- a/mcp-server/src/lib/profile-extract.ts
+++ b/mcp-server/src/lib/profile-extract.ts
@@ -3,7 +3,8 @@
 // dashboard flow (where there's no MCP client to drive structuring).
 
 import type Anthropic from "@anthropic-ai/sdk";
-import { agentModel, getAnthropic } from "./agent/anthropic.js";
+import { getAnthropic } from "./agent/anthropic.js";
+import { aiRequestParams } from "./agent/ai-config.js";
 
 export interface StructuredProfile {
   roles: string[];
@@ -34,8 +35,7 @@ const SYSTEM =
 export async function structureResume(rawText: string): Promise<StructuredProfile> {
   const client = await getAnthropic();
   const resp = await client.messages.create({
-    model: agentModel(),
-    max_tokens: 4000,
+    ...aiRequestParams("structureResume"),
     system: SYSTEM,
     output_config: { format: { type: "json_schema", schema: SCHEMA } },
     messages: [

--- a/mcp-server/src/lib/profile.test.ts
+++ b/mcp-server/src/lib/profile.test.ts
@@ -24,8 +24,11 @@ vi.mock("./store/index.js", () => ({
   }),
 }));
 
-const { readRoles, writeRoles, readProfileFile, writeProfileFile } = await import("./profile.js");
+const { readRoles, writeRoles, readProfileFile, writeProfileFile, writeResumeBlob, readResumeBlob, materializeResumeFile } =
+  await import("./profile.js");
 const { runWithScope } = await import("./run-context.js");
+const { readFileSync, existsSync } = await import("node:fs");
+const { basename } = await import("node:path");
 
 beforeEach(() => docs.clear());
 
@@ -45,6 +48,38 @@ describe("profile tenant isolation (scope = uid)", () => {
     await writeRoles({ detected: ["X"], custom: [], excluded: [] }, "default");
     expect(docs.has("profile::roles.json")).toBe(true);
     expect(docs.has("profile::default__roles.json")).toBe(false);
+  });
+});
+
+describe("resume blob persistence (for Auto-Apply file upload)", () => {
+  const base64 = Buffer.from("%PDF-1.4 fake resume bytes").toString("base64");
+
+  it("round-trips the stored bytes + filename when no GCS bucket is set", async () => {
+    await writeResumeBlob(base64, "My Résumé!.pdf", "userR");
+    const blob = await readResumeBlob("userR");
+    expect(blob).not.toBeNull();
+    expect(blob!.buffer.toString("base64")).toBe(base64);
+    // Filename is sanitized for safe filesystem use.
+    expect(blob!.filename).toBe("My_R_sum__.pdf");
+  });
+
+  it("materializes the resume to a readable temp file", async () => {
+    await writeResumeBlob(base64, "resume.pdf", "userR");
+    const path = await materializeResumeFile("userR");
+    expect(path).toBeTruthy();
+    expect(existsSync(path!)).toBe(true);
+    expect(basename(path!)).toBe("resume.pdf");
+    expect(readFileSync(path!).toString("base64")).toBe(base64);
+  });
+
+  it("returns null when the user has no resume", async () => {
+    expect(await readResumeBlob("nobody")).toBeNull();
+    expect(await materializeResumeFile("nobody")).toBeNull();
+  });
+
+  it("keeps resumes isolated per user", async () => {
+    await writeResumeBlob(base64, "a.pdf", "userA");
+    expect(await readResumeBlob("userB")).toBeNull();
   });
 });
 

--- a/mcp-server/src/lib/profile.ts
+++ b/mcp-server/src/lib/profile.ts
@@ -3,11 +3,14 @@
 // Firestore). The agent reads these at the start of every scrape run so role
 // targeting reflects the real user.
 
-import { existsSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { randomUUID } from "node:crypto";
 import { getStorageConfig, loadConfig } from "../config.js";
 import { getStore } from "./store/index.js";
 import { currentScope } from "./run-context.js";
+import { downloadGcsObject, uploadBufferToGcs } from "./gcs.js";
 
 export type ProfileFile = "skills" | "experience" | "projects";
 
@@ -99,4 +102,78 @@ export async function writeRawResume(text: string, scope: string = scopeDefault(
 
 export async function readRawResume(scope: string = scopeDefault()): Promise<string> {
   return (await (await getStore()).docs.readDoc(NS, docId(scope, "raw-resume.txt"))) ?? "";
+}
+
+// ── Resume binary (for file-upload fields on application forms) ──────────────────
+// We keep the ORIGINAL resume bytes (not just the parsed text) so Auto-Apply can
+// attach the real file to a "Resume/CV" upload field. Storage strategy:
+//   - GCS bucket configured → store the bytes in GCS (object path in the meta doc),
+//     avoiding Firestore's ~1MB per-document cap.
+//   - otherwise → base64 in the docs store (fine for local SQLite/files).
+
+interface ResumeMeta {
+  filename: string;
+  /** GCS object path when stored in GCS; absent when bytes live in the docs store. */
+  gcsObject?: string;
+  updatedAt: string;
+}
+
+/** Persist the original resume bytes + filename for later upload. */
+export async function writeResumeBlob(
+  base64: string,
+  filename: string,
+  scope: string = scopeDefault(),
+): Promise<void> {
+  const store = (await getStore()).docs;
+  const safeName = filename.replace(/[^\w.\-]/g, "_") || "resume.pdf";
+  const gcsObject = await uploadBufferToGcs(
+    Buffer.from(base64, "base64"),
+    `resumes/${scope}/${safeName}`,
+  );
+  const meta: ResumeMeta = { filename: safeName, updatedAt: new Date().toISOString() };
+  if (gcsObject) {
+    meta.gcsObject = gcsObject;
+    // Drop any stale inline copy so we don't keep two sources of truth.
+    await store.deleteDoc(NS, docId(scope, "resume.b64")).catch(() => {});
+  } else {
+    await store.writeDoc(NS, docId(scope, "resume.b64"), base64);
+  }
+  await store.writeDoc(NS, docId(scope, "resume.meta.json"), JSON.stringify(meta));
+}
+
+/** Read the stored resume bytes + filename, or null when none uploaded. */
+export async function readResumeBlob(
+  scope: string = scopeDefault(),
+): Promise<{ buffer: Buffer; filename: string } | null> {
+  const store = (await getStore()).docs;
+  const rawMeta = await store.readDoc(NS, docId(scope, "resume.meta.json"));
+  if (!rawMeta) return null;
+  let meta: ResumeMeta;
+  try {
+    meta = JSON.parse(rawMeta) as ResumeMeta;
+  } catch {
+    return null;
+  }
+  if (meta.gcsObject) {
+    const buf = await downloadGcsObject(meta.gcsObject);
+    return buf ? { buffer: buf, filename: meta.filename } : null;
+  }
+  const b64 = await store.readDoc(NS, docId(scope, "resume.b64"));
+  if (!b64) return null;
+  return { buffer: Buffer.from(b64, "base64"), filename: meta.filename };
+}
+
+/**
+ * Write the stored resume to an OS temp file and return its absolute path so a
+ * browser file-upload field can attach it. Returns null when no resume is stored.
+ * The caller is responsible for cleaning up the returned file when done.
+ */
+export async function materializeResumeFile(scope: string = scopeDefault()): Promise<string | null> {
+  const blob = await readResumeBlob(scope);
+  if (!blob) return null;
+  const dir = join(tmpdir(), `jobsync-resume-${randomUUID()}`);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, blob.filename);
+  writeFileSync(path, blob.buffer);
+  return path;
 }

--- a/mcp-server/src/lib/qa-memory.ts
+++ b/mcp-server/src/lib/qa-memory.ts
@@ -1,0 +1,71 @@
+// Per-user application Q&A memory. When Auto-Apply hits a required question it can
+// neither map from the profile nor confidently compose, it asks the user. The
+// answer is saved here keyed by a normalized question label, so the next time the
+// same question shows up on any form it's filled automatically and the user is
+// never asked twice.
+
+import { getStore } from "./store/index.js";
+import { currentScope } from "./run-context.js";
+
+const NS = "profile";
+const FILE = "qa-memory.json";
+
+function scopeDefault(): string {
+  return currentScope() ?? "default";
+}
+
+function docId(scope: string): string {
+  return scope === "default" ? FILE : `${scope}__${FILE}`;
+}
+
+/** Normalize a field label for matching: lowercase, strip markers, collapse space. */
+export function normalizeLabel(label: string): string {
+  return label
+    .toLowerCase()
+    .replace(/[*:?]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export interface RememberedAnswer {
+  /** The original (un-normalized) label, for display. */
+  label: string;
+  value: string;
+  updatedAt: string;
+}
+
+export type QaMemory = Record<string, RememberedAnswer>;
+
+export async function readQaMemory(scope: string = scopeDefault()): Promise<QaMemory> {
+  const raw = await (await getStore()).docs.readDoc(NS, docId(scope));
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) as QaMemory;
+  } catch {
+    return {};
+  }
+}
+
+/** Look up a remembered answer by (un-normalized) label; undefined when absent. */
+export async function lookupAnswer(
+  label: string,
+  scope: string = scopeDefault(),
+): Promise<string | undefined> {
+  const mem = await readQaMemory(scope);
+  return mem[normalizeLabel(label)]?.value;
+}
+
+/** Persist (merge) a batch of answered questions into the user's Q&A memory. */
+export async function rememberAnswers(
+  answers: Array<{ label: string; value: string }>,
+  scope: string = scopeDefault(),
+): Promise<void> {
+  const filtered = answers.filter((a) => a.label?.trim() && a.value?.trim());
+  if (filtered.length === 0) return;
+  const mem = await readQaMemory(scope);
+  const now = new Date().toISOString();
+  for (const a of filtered) {
+    mem[normalizeLabel(a.label)] = { label: a.label, value: a.value, updatedAt: now };
+  }
+  await (await getStore()).docs.writeDoc(NS, docId(scope), JSON.stringify(mem, null, 2));
+}

--- a/mcp-server/src/tools/link-check-tools.ts
+++ b/mcp-server/src/tools/link-check-tools.ts
@@ -288,6 +288,17 @@ function verifyCached(url: string): Promise<LinkStatus> {
   return withCache(cacheKey("verify_job_link", url), () => verifyDispatch(url), LINK_CHECK_TTL_SECONDS);
 }
 
+/**
+ * Reusable link-liveness check (same board-specific logic + cache the tools use).
+ * Exposed so the post-run audit can re-verify what the agent landed without
+ * going through the MCP tool/JSON round-trip. Returns the raw status struct.
+ */
+export async function checkJobLinkLive(url: string): Promise<LinkStatus> {
+  return verifyCached(url);
+}
+
+export type { LinkStatus };
+
 // ── Tool definitions ─────────────────────────────────────────────────────────
 
 export const verifyJobLinkTool: ToolDefinition = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       mammoth:
         specifier: ^1.8.0
         version: 1.12.0
+      openai:
+        specifier: ^6.42.0
+        version: 6.42.0(zod@3.25.76)
       patchright:
         specifier: ^1.60.2
         version: 1.60.2
@@ -2562,6 +2565,17 @@ packages:
 
   onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
     resolution: {integrity: sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==}
+
+  openai@6.42.0:
+    resolution: {integrity: sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==}
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   option@0.2.4:
     resolution: {integrity: sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==}
@@ -5806,6 +5820,10 @@ snapshots:
       onnxruntime-common: 1.22.0-dev.20250409-89f8206ba4
       platform: 1.3.6
       protobufjs: 7.6.2
+
+  openai@6.42.0(zod@3.25.76):
+    optionalDependencies:
+      zod: 3.25.76
 
   option@0.2.4: {}
 


### PR DESCRIPTION
## What does this PR do?

Adds Phases 1–2 of the agent robustness + eval roadmap, plus the shared AI-call configuration system. **(1)** A **post-run audit** for the Search agent: after the tool-use loop ends, `auditSearchRun()` independently re-verifies every job the agent landed on four axes — recency (against the lookback window), link liveness (reusing the exact board-specific checkers via the newly-exported `checkJobLinkLive()`), title-vs-target-roles, and no-fabrication (every upserted link must appear in a prior tool result) — then flags offending pipeline rows via a notes-only, idempotent `annotatePipelineEntries()` that never touches application status. **(2)** The **eval fixture foundation**: a record/replay `fetch` interceptor (`fixture-fetch.ts`) so the existing fetchers and the link verifier replay a snapshotted day of ATS responses with zero code changes, a frozen-clock helper (`clock.ts`, `JOBSYNC_FAKE_NOW`) wired as the audit's default clock, and a `record-fixtures.ts` snapshot script that emits `ground-truth.json` for eval reference solutions. **(3)** A centralized `ai.config.json` system (models, token/temperature, search-loop budgets) for all four Anthropic call sites, with `JOBSYNC_AGENT_MODEL` still winning as the deploy/eval-matrix override. Full design and the remaining Phases 3–5 are documented in `docs/agent-architecture-and-evals.md`.

Part of #39

## How was it verified?

- [x] `pnpm --filter jobsync-mcp typecheck` passes (`tsc -p mcp-server/tsconfig.json --noEmit`, exit 0)
- [x] `pnpm --filter jobsync-mcp build` passes (tsup, build success)
- [x] `pnpm --filter jobsync-mcp test` passes (168 tests across 16 files — includes new search-audit, pipeline-annotate, fixture-fetch, clock, and ai-config suites)
- [ ] Tested manually against Claude Code / Claude Desktop (no MCP tool surface changed; audit/fixtures/config are server-internal — fixture replay is covered by unit tests, not yet exercised against a live board snapshot)

## Checklist

- [x] Scoped to one problem or feature — agent-evals Phases 1–2 + the AI-config system they build on
- [x] No secrets, Airtable tokens, resumes, or personal data included
- [x] Docs updated if CLI commands, MCP tool names, or config keys changed — `docs/agent-architecture-and-evals.md`; `ai.config.json` keys documented inline
- [x] New or updated tests included for logic changes — search-audit (14), pipeline annotate (4), fixture-fetch (8), clock (3), agent wiring (+2), ai-config (4)
